### PR TITLE
remove parent path reference when using lab-report

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -599,7 +599,7 @@
 
 \AtBeginDocument{
   \if@bit@labreport
-    \input{../lab-report/misc/cover_v1.tex}
+    \input{misc/cover_v1.tex}
     % 正文开始
     \pagestyle{fancy}
     \setcounter{page}{1}%


### PR DESCRIPTION
Next time when using the lab-report, the name of working directory won't have to be **lab-report**.