### PR TITLE
Make `rm` can work on Windows (really)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,6 @@ SCAFFOLDDIR = ./templates
 TESTDIR = ./tests
 EXAMPLEDIR = ./examples
 
-# make deletion work on Windows
-ifdef SystemRoot
-  RM = del /Q
-else
-  RM = rm -f
-endif
 
 .PHONY: all cls doc clean FORCE_MAKE copy
 
@@ -38,10 +32,10 @@ viewdoc: doc
 
 clean:
 	$(LATEXMK) -c $(PACKAGE).dtx
-	-@$(RM) -r *.glo $(CLSFILE)
+	-rm -rf *.glo $(CLSFILE)
 
 clean-dist:
-	-@$(RM) -r $(PACKAGE).pdf
+	-rm -rf $(PACKAGE).pdf
 
 clean-all: clean clean-dist FORCE_MAKE
 


### PR DESCRIPTION
This PR makes the following works.

```mermaid
flowchart LR
    pwsh["PowerShell<br>(of VS Code)"]
    --> make["<code>make</code>"]
    --> bash["bash<br>(from Git for Windows / MSYS2)"]
```

`$SYSTEMROOT` implies who calls `make`,  not who `make` calls. PowerShell users can [let `make` use bash](https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html), and it should work.

Additionally, `$SYSTEMROOT` is about OS rather than the shell. If you call `make` from bash on MSYS2 (on Windows), then `$SYSTEMROOT` also exists, but `del` doesn't.

Moreover, Command Prompt's `del` cannot understand `-r`.

---

Relevant: #180 