### PR TITLE
fix: set font by font file names (in stead of font names).

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1376,7 +1376,7 @@
 %
 % \begin{latex}
 %   \unimathsetup{bold-style=ISO}
-%   \setmathfont{XITS Math}
+%   \setmathfont{XITSMath-Regular.otf}
 % \end{latex}
 %
 % \textit{请事先安装 XITS 字体。}


### PR DESCRIPTION
Fonts installed by TeXLive cannot be found via font names on macOS.