### PR TITLE
Update bitbeamer.cls

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -5509,7 +5509,10 @@
 % 设置主题与主题色。
 %    \begin{macrocode}
 \usetheme{Madrid}
-\colorlet{beamer@blendedblue}{green!40!black}
+\definecolor{bitred}{HTML}{A13E0B}
+\definecolor{bitgreen}{HTML}{0A8F30}
+\definecolor{bitdarkgreen}{HTML}{005B30}
+\colorlet{beamer@blendedblue}{bitdarkgreen}
 %    \end{macrocode}
 % 
 %

--- a/templates/presentation-slide/bitbeamer.cls
+++ b/templates/presentation-slide/bitbeamer.cls
@@ -42,7 +42,10 @@
 \RequirePackage{xeCJKfntef}
 \RequirePackage{tikz}
 \usetheme{Madrid}
-\colorlet{beamer@blendedblue}{green!40!black}
+\colordefine{bitred}{HTML}{A13E0B}
+\colordefine{bitgreen}{HTML}{0A8F30}
+\colordefine{bitdarkgreen}{HTML}{005B30}
+\colorlet{beamer@blendedblue}{bitdarkgreen}
 \cs_new:Npn \CJKhl:nn #1 #2
   { \CJKsout*[thickness=2.5ex, format=\color{#1}]{#2} }
 \tl_if_empty:NF \l_bit_titlegraphic_tl {

--- a/templates/presentation-slide/bitbeamer.cls
+++ b/templates/presentation-slide/bitbeamer.cls
@@ -42,9 +42,9 @@
 \RequirePackage{xeCJKfntef}
 \RequirePackage{tikz}
 \usetheme{Madrid}
-\colordefine{bitred}{HTML}{A13E0B}
-\colordefine{bitgreen}{HTML}{0A8F30}
-\colordefine{bitdarkgreen}{HTML}{005B30}
+\definecolor{bitred}{HTML}{A13E0B}
+\definecolor{bitgreen}{HTML}{0A8F30}
+\definecolor{bitdarkgreen}{HTML}{005B30}
 \colorlet{beamer@blendedblue}{bitdarkgreen}
 \cs_new:Npn \CJKhl:nn #1 #2
   { \CJKsout*[thickness=2.5ex, format=\color{#1}]{#2} }


### PR DESCRIPTION
在beamer模板中定义了三个北理工官方给出的[标准颜色](https://www.bit.edu.cn/gbxxgk/gbjswh/vixx/xxbzs/index.htm)，分别命名为bitred, bitgreen, bitdarkgreen

P.S. 网站上的北理绿的G和B写反了