### PR TITLE
build: PowerShell version of regression-test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,8 +288,9 @@ bithesis
 overleaf
 *.zip
 
-scripts
+scripts/*
 !scripts/*.sh
 !scripts/*.zsh
+!scripts/*.ps1
 
 .DS_Store

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,9 +70,9 @@ make doc
 运行 `make regression-test` 进行回归测试，该命令将比较目前已发布的最新版本和本地版本生成的 PDF 的差异。
 使用前请确保已经安装下面这些依赖。
 
-- [zsh](https://github.com/ohmyzsh/ohmyzsh/wiki/Installing-ZSH)（POSIX）或 [PowerShell 7](https://learn.microsoft.com/zh-cn/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.3)（Windows）
+- [Zsh](https://github.com/ohmyzsh/ohmyzsh/wiki/Installing-ZSH)（POSIX）或 [PowerShell 7](https://learn.microsoft.com/zh-cn/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.3)（Windows）
 - [diff-pdf](https://vslavik.github.io/diff-pdf/)
-- [jq](https://jqlang.github.io/jq/)（仅用 zsh 时需要）
+- [jq](https://jqlang.github.io/jq/)（仅用 Zsh 时需要）
 
 运行 `make check-cls` 确保 `bithesis.dtx` 的修改都被同步到了 `templates/` 中。
 （同样被用于 GitHub Actions）

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,7 +7,7 @@
 
 ## 开发命令
 
-Makefile 主要针对 Linux 和 MacOS 开发者；如果你使用 Windows 开发，可能需要手动执行 Makefile 中具体的命令。
+Makefile 主要针对 Linux 和 MacOS 开发者；如果你使用 Windows 开发，可以使用 Git Bash 或 Cygwin，不过偶尔可能需要手动执行 Makefile 中具体的命令。
 
 当然，也欢迎你贡献更通用的开发脚本。
 
@@ -68,7 +68,11 @@ make doc
 运行 `make test` 将对所有的模板进行编译测试（同样被用于 GitHub Actions）。
 
 运行 `make regression-test` 进行回归测试，该命令将比较目前已发布的最新版本和本地版本生成的 PDF 的差异。
-使用前请确保 `diff-pdf`、`zsh` 已经安装。
+使用前请确保已经安装下面这些依赖。
+
+- [zsh](https://github.com/ohmyzsh/ohmyzsh/wiki/Installing-ZSH)（POSIX）或 [PowerShell 7](https://learn.microsoft.com/zh-cn/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.3)（Windows）
+- [diff-pdf](https://vslavik.github.io/diff-pdf/)
+- [jq](https://jqlang.github.io/jq/)（仅用 zsh 时需要）
 
 运行 `make check-cls` 确保 `bithesis.dtx` 的修改都被同步到了 `templates/` 中。
 （同样被用于 GitHub Actions）

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# 以下命令仅能在 Linux 或 MacOS 环境下执行。
-# 如果你是 windows 用户，可以使用 git bash 或者 cygwin 来执行；
+# 以下命令仅保证能在 Linux 或 MacOS 环境下执行。
+# 如果你是 Windows 用户，可以使用 Git Bash 或者 Cygwin 来执行；
 # 或者可以考虑将此脚本移植为 PowerShell。
 PACKAGE = bithesis
 
@@ -13,6 +13,12 @@ LATEXMK = latexmk
 SCAFFOLDDIR = ./templates
 TESTDIR = ./tests
 EXAMPLEDIR = ./examples
+
+ifeq ($(OS), Windows_NT)
+	REGRESSION_TEST_COMMAND=pwsh ./scripts/regression-testing.ps1
+else
+	REGRESSION_TEST_COMMAND=zsh ./scripts/regression-testing.zsh
+endif
 
 
 .PHONY: all cls doc clean FORCE_MAKE copy
@@ -50,7 +56,7 @@ test: doc copy FORCE_MAKE
 	cd $(TESTDIR)/autorefs && latexmk && cd ..
 
 regression-test: cls
-	zsh ./scripts/regression-testing.zsh
+	$(REGRESSION_TEST_COMMAND)
 
 copy: cls
 	cp bithesis.cls $(SCAFFOLDDIR)/undergraduate-thesis

--- a/scripts/regression-testing.ps1
+++ b/scripts/regression-testing.ps1
@@ -1,0 +1,84 @@
+# Convert from ./regression-testing.zsh by GPT-3.5-turbo
+# Modified by humans
+
+$ErrorActionPreference = "Stop"
+$USE_GHPROXY = $true
+
+Push-Location (Split-Path -Path $MyInvocation.MyCommand.Path -Parent)
+Write-Host (Get-Location)
+
+$REPO = "BITNP/BIThesis"
+
+$CACHE_FILE = "latest.json"
+
+$CACHE_CUR_VERSION_FILE = "cache_current_version.txt"
+
+# download latest files if not cached
+Write-Host "get current version"
+
+if (Test-Path $CACHE_CUR_VERSION_FILE) {
+  $CUR_VERSION = Get-Content $CACHE_CUR_VERSION_FILE
+}
+else {
+  $uri = "https://api.github.com/repos/$REPO/releases/latest"
+  $headers = @{ "Accept" = "application/vnd.github.v3+json" }
+  Invoke-RestMethod -Uri $uri -Headers $headers -OutFile $CACHE_FILE
+  $CUR_VERSION = ""
+}
+
+Write-Host "get current cache"
+$ZIP_URL = (Get-Content $CACHE_FILE | ConvertFrom-Json).assets.browser_download_url
+$VERSION = (Get-Content $CACHE_FILE | ConvertFrom-Json).tag_name
+
+$ZIP_URL = $ZIP_URL -split "`n"
+
+if ($VERSION -ne $CUR_VERSION) {
+  Write-Host "try download latest version: $VERSION."
+  Write-Host $ZIP_URL
+
+  foreach ($url in $ZIP_URL) {
+    if ($url -like "*.zip") {
+      $url = if ($USE_GHPROXY) { "https://ghproxy.com/$url" } else { $url }
+      Invoke-WebRequest -Uri $url -OutFile (Split-Path -Leaf $url)
+    }
+  }
+
+  $VERSION > $CACHE_CUR_VERSION_FILE
+}
+else {
+  Write-Host "$VERSION already downloaded."
+}
+
+Write-Host "current dir: $(Get-Location)"
+
+foreach ($url in $ZIP_URL) {
+  if ($url -like "*.zip") {
+    $file_name = Split-Path -Leaf $url
+    Expand-Archive -LiteralPath $file_name -DestinationPath . -Force
+    $dir_name = $file_name -replace "\.zip$"
+
+    if ($FILTER -and $FILTER -ne $dir_name) {
+      # skip this file
+      continue
+    }
+
+    Write-Host "============== start $url ==============="
+
+    # build latest release version on github
+    Push-Location $dir_name
+    Remove-Item -Path '*.pdf', '*.aux' -ErrorAction SilentlyContinue
+    latexmk
+    Pop-Location
+
+    # build current version
+    Push-Location "../templates/$dir_name"
+    Remove-Item -Path '*.pdf', '*.aux' -ErrorAction SilentlyContinue
+    latexmk
+    Pop-Location
+
+    diff-pdf --view "./$dir_name/main.pdf" "../templates/$dir_name/main.pdf"
+    Write-Host "============== end $url ==============="
+  }
+}
+
+Pop-Location


### PR DESCRIPTION
Windows 上使用 make 甚至 bash 都有可能，但 zsh 恐怕不太行，所以翻译成了`scripts/regression-test.ps1`。

- PowerShell 有`ConvertFrom-Json`，无需 jq。（虽然 jq 也很容易安装）
- `.gitignore`中不能忽略`scripts/`目录，不然后续`!`无效。

Relates-to: #180