### PR TITLE
doc: 更新教务部网站

### DIFF
--- a/README-bithesis.md
+++ b/README-bithesis.md
@@ -13,7 +13,7 @@ The current maintainer of this project is [Feng Kaiyu](https://github.com/fky201
 BIThesis is an unofficial LaTeX template set for your 
 **undergraduate, master, or doctoral thesis** as well as other academic writing here at BIT.
 
-This project is supported by the _[Dept. of Undergraduate Academic Affairs, BIT](https://jwc.bit.edu.cn/)_ and the _[School of Computer Science and Technology, BIT](https://cs.bit.edu.cn/)_. See [Acknowledgements - Official Sponsors](https://bithesis.bitnp.net/guide/acknowledgements.html#%E5%AE%98%E6%96%B9%E8%B5%9E%E5%8A%A9-official-sponsors).
+This project is supported by the _[Dept. of Undergraduate Academic Affairs, BIT](https://jwb.bit.edu.cn/)_ and the _[School of Computer Science and Technology, BIT](https://cs.bit.edu.cn/)_. See [Acknowledgements - Official Sponsors](https://bithesis.bitnp.net/guide/acknowledgements.html#%E5%AE%98%E6%96%B9%E8%B5%9E%E5%8A%A9-official-sponsors).
 
 At present, `bithesis` only supports XeTeX and LuaTeX engines. `bithesis` only allows `UTF-8` encoding.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _（此文档已被包含在 [Releases][releases] 的文件中）_
 
 BIThesis 是针对北京理工大学本科生毕业设计论文、研究生学位论文的一个非官方的 LaTeX 模板，BIThesis 同时也包括其他本科学习中涉及到的文献综述、实验报告等的 LaTeX 模板。
 
-> 本项目获得了 [北京理工大学教务部](http://jwc.bit.edu.cn/)、[北京理工大学计算机学院](http://cs.bit.edu.cn/) 的认可、背书与大力支持。详见：[致谢 - 官方赞助](https://bithesis.bitnp.net/guide/acknowledgements.html#%E5%AE%98%E6%96%B9%E8%B5%9E%E5%8A%A9-official-sponsors)。
+> 本项目获得了 [北京理工大学教务部](http://jwb.bit.edu.cn/)、[北京理工大学计算机学院](http://cs.bit.edu.cn/) 的认可、背书与大力支持。详见：[致谢 - 官方赞助](https://bithesis.bitnp.net/guide/acknowledgements.html#%E5%AE%98%E6%96%B9%E8%B5%9E%E5%8A%A9-official-sponsors)。
 
 > **研究生模板正在完成与研究生院的沟通。[__（进度详情）__](https://github.com/BITNP/BIThesis/issues/163)**
 


### PR DESCRIPTION
[jwc](https://jwc.bit.edu.cn)（教务部）→ [jwb](https://jwb.bit.edu.cn)（教务部）。大概2023年3月改的。旧站仍在线，但只是部分正常。