### PR TITLE
fix: note environment does not work as expected

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -3955,8 +3955,9 @@
 \DeclareDocumentCommand{\env}{m}{\texttt{#1}}
 \newcommand{\myentry}[1]{%
   \marginpar{\raggedleft\color{purple}\bfseries\strut #1}}
-\newcommand{\note}[2][Note]{{%
-  \color{magenta}{\bfseries #1}\emph{#2}}}
+\newenvironment{note}[1][Note]
+  {{\color{magenta} \bfseries #1} \itshape}
+  {}
 
 \DeclareDocumentCommand{\githubuser}{m}{\href{https://github.com/#1}{@#1}}
 


### PR DESCRIPTION
- 包了一下`\color`。
- 把`\newcommand`改成了`\newenvironment`。不是很懂原来为什么能当 environment 用……

Fixes #375 

## Before

![](https://user-images.githubusercontent.com/73375426/249832180-5f988490-b73b-4b61-9b62-6cd4d279cf05.png)

## After

![](https://github.com/BITNP/BIThesis/assets/73375426/3dcc3b46-da34-4274-b6fe-922cfd76fc81)
