### PR TITLE
fix: typo in release-tracker.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-tracker.md
+++ b/.github/ISSUE_TEMPLATE/release-tracker.md
@@ -6,7 +6,7 @@ labels: Release
 ---
 
 - [ ] 提升版本号到最新
-- [ ] 生成 CHANGLOG
+- [ ] 生成 CHANGELOG
 - [ ] 通过单元测试
 - [ ] `bithesis` 是否需要更新
   - [ ] 上传 CTAN


### PR DESCRIPTION
`CHANGLOG` → `CHANGELOG`. (-E-)