### PR TITLE
doc: Unify the case of “GitHub”

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -245,7 +245,7 @@ BIThesis-wiki
   \item  CTAN 发布：
     \href{https://ctan.org/pkg/bithesis}{CTAN bithesis package}
   \item  GitHub 发布：
-    \href{https://github.com/BITNP/BIThesis/releases}{Github Releases}
+    \href{https://github.com/BITNP/BIThesis/releases}{GitHub Releases}
     \footnote{最推荐使用此种方式}
   \item  Overleaf 发布：
     \href{https://bithesis.bitnp.net}{Overleaf Templates}
@@ -261,7 +261,7 @@ GitHub 和 Overleaf 上发布的是 \BIThesisLaTeX 的完整模板，因此想�
   \item 将旧模板中的写作内容复制到新模板中。
 \end{itemize}
 
-需要注意的是，Github 和 Overleaf 的模板中包含了当前版本的 |*.cls| 文件，
+需要注意的是，GitHub 和 Overleaf 的模板中包含了当前版本的 |*.cls| 文件，
 因此不会因为 CTAN 上的更新而导致模板无法编译。（但代价当然是需要手动升级）
 
 GitHub 同时提供了独立的 |*.cls| 文件，可以仅下载 |*.cls| 文件并通过上述
@@ -324,7 +324,7 @@ tlmgr update bithesis
 更新的版本可能会修复一些 bug，也可能会增加新的功能。
 
 因此，首先建议你首先查看最新版本与你当前版本的差异，以便决定是否升级。
-你可以通过 Github Releases 或者 ChangeLog 来查看更新内容。
+你可以通过 GitHub Releases 或者 ChangeLog 来查看更新内容。
 
 当你决定升级时，请首先备份你的工作目录，然后按照\ref{sec:release}节的描述进行升级。
 


### PR DESCRIPTION
将手册中的“Github”改为“GitHub”。
