### PR TITLE
fix: Update styles of PT

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2159,7 +2159,7 @@
 
           \zihao{2}\textbf{\songti{\l_@@_style_headline_tl}}
 
-          \vspace{10mm}
+          \vspace{25mm}
 
           {
 
@@ -2171,8 +2171,8 @@
             \dim_set:Nn \l_@@_cover_value_max_width_dim {115mm}
 
             \clist_set:Nn \l_@@_input_clist {
-              {\zihao{4}\textbf{外文原文题目}} {\l_@@_value_trans_origin_title_tl},
-              {\zihao{4}\textbf{中文翻译题目}} {\l_@@_value_trans_title_tl},
+              {\songti\zihao{4}\textbf{外文原文题目}} {\l_@@_value_trans_origin_title_tl},
+              {\songti\zihao{4}\textbf{中文翻译题目}} {\l_@@_value_trans_title_tl},
             }
 
             \zihao{-3}
@@ -2184,7 +2184,7 @@
 
           }
 
-          \vspace{19mm}
+          \vspace{23mm}
 
           \zihao{2}\textbf{\xihei:n \l_@@_value_title_tl}\par
 


### PR DESCRIPTION
参照2023年12月相关通知修改封面：

- 微调`\vspace`。
- “外文原文题目：”和“中文翻译题目：”改为宋体。

[`undergraduate-thesis`及`paper-translation`与2023年模板的区别 · Discussion #396](https://github.com/BITNP/BIThesis/discussions/396) 提到的其它区别我不打算改了；PT 主要是字体变了，改一下。

回归测试：

![图片](https://github.com/BITNP/BIThesis/assets/73375426/a7acbc3e-fdd5-47f1-96af-63f4e94e6200)


另外，调试时用到了以下脚本，以后可能有用。

```pwsh
# Prerequisites:
# - [toastify](https://github.com/hoodie/toastify)
# - [diffpdf](https://soft.rubypdf.com/software/diffpdf)

Push-Location ../..
make cls
Pop-Location
toastify send BIThesis "✅ bithesis.cls"

Copy-Item ../../bithesis.cls

latexmk
toastify send BIThesis "✅ main.pdf"

diffpdf ./main.pdf ./ref.pdf
```