### PR TITLE
refactor: Stretch spaces in the cover of PT

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2159,7 +2159,8 @@
 
           \zihao{2}\textbf{\songti{\l_@@_style_headline_tl}}
 
-          \vspace{25mm}
+          % 外文翻译封面有两组中英文标题，行数变化范围大，因此采用 fill 比例布局
+          \vspace{\stretch{1}}
 
           {
 
@@ -2184,7 +2185,7 @@
 
           }
 
-          \vspace{23mm}
+          \vspace{\stretch{1}}
 
           \zihao{2}\textbf{\xihei:n \l_@@_value_title_tl}\par
 
@@ -2194,7 +2195,7 @@
             \zihao{3}\selectfont{\textbf{\l_@@_value_title_en_tl}}\par
           \end{spacing}
 
-          \vspace{19mm}
+          \vspace{\stretch{0.67}}
 
           \begin{spacing}{1.8}
             \tl_if_empty:NT \l_@@_cover_dilimiter_tl {
@@ -2229,7 +2230,7 @@
             
           \end{spacing}
 
-          \vspace*{\fill}
+          \vspace{\stretch{0.67}}
         \end{titlepage}
       }
       {3} {


### PR DESCRIPTION
外文翻译封面有两组中英文标题，行数变化范围大（可能相差3行），行太多时会挤到下一页。为避免这种可能，采用`fill`比例布局。

其它模板的学院、专业也可能加行，但版面没这么紧，所以没改。

历史：@CZLeader 用了 https://github.com/BITNP/BIThesis/releases/tag/v3.6.1 ，四个标题都占两行，“指导教师”会挤到第二页。在发布的版本之后，#399 (f32503b) 改了这个间距，这个问题仍存在，且更容易被触发了。

<details>
<summary>学校 Word 模板也有这个问题</summary>

![](https://github.com/BITNP/BIThesis/assets/73375426/c889fbbf-f234-4d30-8d2a-053b1561f343)

</details>

## 此 PR 与学校 Word 模板对比

（有对话框的是学校 Word 模板）

![](https://github.com/BITNP/BIThesis/assets/73375426/b3e2708f-fdec-41e4-ad8f-79171b42019b)

![](https://github.com/BITNP/BIThesis/assets/73375426/30d59312-feec-4895-a6fb-a4ee1fa35d58)

## 相关链接

[spacing - Lengths and when to use them - TeX - LaTeX Stack Exchange](https://tex.stackexchange.com/questions/41476/lengths-and-when-to-use-them)