### PR TITLE
fix: Remove `, et al.` etc. for `pub.bib` in `blindPeerReview` mode

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2940,6 +2940,15 @@
         \DeclareDelimFormat{multinamedelim}{}
         % 如果覆盖的是英文作者，不修改此项的话，会在最开始有空格。
         \DeclareDelimFormat{bibnamedelimd}{}
+
+        % 如果作者太多而被截断，不修改的话，会多余逗号、“等”云云。
+        % 被截断的充要条件：作者数量大于通过`\BITSetup`设置的`publications/maxbibnames`。
+        % 故设置标点来去掉逗号，
+        \DeclareDelimFormat[bib,biblist]{andothersdelim}{}
+        % 并设置本地化字符串来去掉“等”。
+        \setlocalbibstring{andothers}{}
+        \setlocalbibstring{andotherscn}{}
+        % 另外注意，我们仍尊重`maxbibnames`和`minbibnames`，保证若开盲审时显示作者，则关盲审时也正常。
       }
 
       % ===== 上方定义与「参考文献」部分相同


### PR DESCRIPTION
Fixes #410

这个做法在`biblatex`和`biblatex-gb7714-2015`的手册里有，并不是很hack。

![](https://github.com/BITNP/BIThesis/assets/73375426/bbdaa247-454f-472a-9541-10911164f53d)

### 测试例子

`templates/graduate-thesis/main.tex`：设置盲审模式，显示3个作者（国标要求只显示1个，但想显示自己）。

```diff
-\documentclass[type=master,twoside]{bithesis}
+\documentclass[type=master,twoside,blindPeerReview=true]{bithesis} % 或者false

 \BITSetup{
@@ -90,7 +90,7 @@
     % 一般来说，如果你在全部文献中最低排在第四位，建议你将两个值都设置为 4。
     % 更详细的说明请见手册。
     maxbibnames = 3,
-    minbibnames = 1,
+    minbibnames = 3,
   },
```

`templates/graduate-thesis/reference/pub.bib`：多加些作者。

```diff
 @article{myCiteKey,
   title = {交联型与线形水性聚氨酯的形状记忆性能比较},
-  author = {张三 and 李杰 and 罗运军},
+  author = {张三 and 李杰 and 罗运军 and 汪淼},
   author+an = {1:myself="\Author"},
@@ -80,7 +80,7 @@
 }

 @book{dummy:2,
-  author = "John Doe and San Zhang",
+  author = "John Doe and San Zhang and White Ice and AAA",
   author+an = {2:myself="\AuthorEn[2]"},
```

### 之前

关盲审：
![图片](https://github.com/BITNP/BIThesis/assets/73375426/ab61867b-ecd7-49ad-8359-8c912fbe324e)
开盲审：
![图片](https://github.com/BITNP/BIThesis/assets/73375426/21325207-750e-4784-a71d-c72a11d6bff0)

### 之后

关盲审：
![图片](https://github.com/BITNP/BIThesis/assets/73375426/c85f128d-ae6f-4a80-995d-5701c6726d4f)
开盲审：
![图片](https://github.com/BITNP/BIThesis/assets/73375426/02cecfab-0ac2-4842-9232-074bc0797dfb)
