### PR TITLE
CI: Upload to CTAN and minor fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-tracker.md
+++ b/.github/ISSUE_TEMPLATE/release-tracker.md
@@ -7,8 +7,6 @@ labels: Release
 
 - [ ] 提升版本号到最新
 - [ ] 通过单元测试
-- [ ] `bithesis` 是否需要更新
-  - [ ] 上传 CTAN
 - [ ] 上传新的模板到 Overleaf
 - [ ] 模板是否需要更新
   - [ ] 发布新的 Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "*.*.*"
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -178,3 +178,39 @@ jobs:
           git add CHANGELOG.md
           git commit -m "Update CHANGELOG"
           git push https://${{ secrets.GITHUB_TOKEN }}@github.com/BITNP/BIThesis.git main
+
+  upload_to_ctan:
+    name: Upload to CTAN
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ ! github.event.release.prerelease }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download bithesis.pdf
+        uses: actions/download-artifact@v3
+        with:
+          name: bithesis
+      - run: make pkg-only
+      - name: Determine version
+        id: version
+        run: |
+          version=${{ github.event.release.tag_name }}
+          echo "number=$(echo $version | sed 's/^v//')" >> "$GITHUB_OUTPUT"
+          echo "date=$(date '+%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+      - name: Upload to CTAN
+        uses: paolobrasolin/ctan-submit-action@v1
+        with:
+          action: upload
+          file_path: bithesis.zip
+          fields: |
+            update: "true"
+            pkg: bithesis
+            version: ${{ steps.version.outputs.number }} ${{ steps.version.outputs.date }}
+            author: Feng Kaiyu
+            email: loveress01@outlook.com
+            uploader: Feng Kaiyu
+      - name: Report
+        run: >
+          echo "🎉 Successfully upload
+          ${{ steps.version.outputs.number }} (${{ steps.version.outputs.date }})
+          to [CTAN](https://www.ctan.org/pkg/bithesis)." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
           asset_name: ${{ matrix.cls }}.cls
           tag: ${{ github.ref }}
 
-  publish_pdfs:
+  update_changelog:
     name: Generate changelog
     runs-on: ubuntu-latest
     # Makesure it's the last job.
@@ -151,33 +151,6 @@ jobs:
           overwrite: true
           body: |
             ${{ steps.git-cliff.outputs.content }}
-
-  update_changelog:
-    name: Generate changelog
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate a changelog
-        uses: orhun/git-cliff-action@v3
-        with:
-          config: cliff.toml
-          args: --verbose
-        env:
-          OUTPUT: CHANGELOG.md
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          set +e
-          git add CHANGELOG.md
-          git commit -m "Update CHANGELOG"
-          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/BITNP/BIThesis.git main
 
   upload_to_ctan:
     name: Upload to CTAN

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,7 +78,7 @@ make doc
 ## 打包
 
 - `make overleaf version=X.X.X` 可以生成上传 overleaf 所需要的 zip 文件。
-- `make pkg` 可以生成上传 CTAN 所需要的 zip 文件。若已有手册而不想重新编译，可 `make pkg-only`。
+- `make pkg` 可以生成上传 CTAN 所需要的 zip 文件。若已有手册而不想重新编译，可 `make pkg-only`。（同样被用于 GitHub Actions）
 - `make grad version=X.X.X` 可以生成用作研究生院官网附件的 zip 文件。
 
 ## 上传 Overleaf 与更新

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,7 +78,7 @@ make doc
 ## 打包
 
 - `make overleaf version=X.X.X` 可以生成上传 overleaf 所需要的 zip 文件。
-- `make pkg` 可以生成上传 CTAN 所需要的 zip 文件。
+- `make pkg` 可以生成上传 CTAN 所需要的 zip 文件。若已有手册而不想重新编译，可 `make pkg-only`。
 - `make grad version=X.X.X` 可以生成用作研究生院官网附件的 zip 文件。
 
 ## 上传 Overleaf 与更新

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
 endif
 
 
-.PHONY: all cls doc clean FORCE_MAKE copy
+.PHONY: all cls doc clean FORCE_MAKE copy pkg pkg-only
 
 $(PACKAGE).pdf: cls FORCE_MAKE
 	@$(LATEXMK) -xelatex $(PACKAGE).dtx
@@ -94,12 +94,14 @@ dev:
 dev-doc:
 	ls bithesis.dtx | entr -s 'make clean-all && yes y | make doc && open bithesis.pdf'
 
-pkg: doc
+pkg-only:
 	rm -rf ./bithesis ./bithesis.zip
 	mkdir bithesis
-	cp bithesis.{ins,dtx,pdf} ./README*.md ./contributing*.md ./bithesis
+	cp bithesis.ins bithesis.dtx bithesis.pdf ./README*.md ./contributing*.md ./bithesis
 	mv ./bithesis/README-bithesis.md ./bithesis/README.md
 	zip -r bithesis.zip bithesis
+
+pkg: doc pkg-only
 
 GRAD_DEST_DIR = ./BIThesis-graduate-thesis-template
 


### PR DESCRIPTION
- **触发条件**：发布正式 release。

- **功能**：下载`.github/workflows/release.yml`中`build`上传的手册，打包，上传到CTAN。

- **版本号**：发布 release 时从 tag name 提取。

之前运行记录：

- 触发条件：https://github.com/YDX-2147483647/BIThesis/releases/tag/v3.7.0-alpha.0
- 结果：https://github.com/YDX-2147483647/BIThesis/actions/runs/8415011474/attempts/1#summary-23039595164

Relates-to: #425 

<details>
<summary>旧版</summary>

https://github.com/BITNP/BIThesis/commit/bbe373d367925522e62f870cdb4a8a79872ea4dd

- **功能**：下载`.github/workflows/release.yml`上传的手册，打包，上传到CTAN。

  注意手册是从 artifact 下载，并不会重新编译。

- **触发条件**：发布 release 或手动触发。

- **版本号**：发布 release 时从 tag name 提取（尚未测试），手动触发时人为指定。

  文件中还实现了从最后一次 release 提取 tag name，仅为备用，正常会跳过。

之前运行记录： https://github.com/YDX-2147483647/BIThesis/actions/workflows/ctan.yml

Relates-to: #425 

### 未来需要的更改

“Upload to CTAN”这步的`action: validate`要改成`action: upload`。`validate`只是验证，并不更改CTAN上的东西；`upload`才是真的上传。

另：CTAN似乎没有验证，难道随便谁都能上传？

</details>