### PR TITLE
处理字体警告

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -5,6 +5,7 @@ usera = "usera"
 multline = "multline"
 Winn = "Winn"
 nd = "nd"
+thm = "thm"
 
 [files]
-extend-exclude = ["CHANGELOG.md", "main.bib"]
+extend-exclude = ["CHANGELOG.md", "main.bib", "latexmkrc"]

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -287,14 +287,36 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\boxempty:}
+% 空的选框。
+%    \begin{macrocode}
+\cs_new:Npn \boxempty:
+{
+  \makebox[1em][l]
+  {
+    % 为保证与打了勾的一致，也需套盒子
+    \makebox[0pt][l]
+    {
+      % 默认比基线略高，向下降降
+      \raisebox{-1pt}{$\square$}
+    }
+  }
+}
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}{\boxcheck:}
-% 标签文字之间的间距。
+% 打了勾的选框。
 %    \begin{macrocode}
 \cs_new:Npn \boxcheck:
 {
   \makebox[1em][l]
   {
-    \makebox[1pt][l]{$\boxempty$}
+    \makebox[0pt][l]
+    {
+      % 默认比基线略高，向下降降
+      \raisebox{-1pt}{$\square$}
+    }
     $\checkmark$
   }
 }
@@ -405,11 +427,11 @@
   {
     {originality} {研究成果声明},
     {originality_clause} {本人郑重声明：所提交的学位论文是我本人在指导教师的指导下独立完成的研究成果。文中所撰写内容符合以下学术规范（请勾选）：
-\par $\boxcheck:$ 论文综述遵循“适当引用”的规范，全部引用的内容不超过50\%。
-\par 论文中的研究数据及结果不存在篡改、剽窃、抄袭、伪造等学术不端行为，并愿意承担因学术不端行为所带来的一切后果和法律责任。
-\par $\boxcheck:$文中依法引用他人的成果，均已做出明确标注或得到许可。
-\par $\boxcheck:$论文内容未包含法律意义上已属于他人的任何形式的研究成果，也不包含本人已用于其他学位申请的论文或成果。
-\par $\boxcheck:$与本人一同工作的合作者对此研究工作所做的任何贡献均已在学位论文中作了明确的说明并表示了谢意。
+\par \boxcheck:\hspace{0.5em} 论文综述遵循“适当引用”的规范，全部引用的内容不超过50\%。
+\par \boxcheck:\hspace{0.5em} 论文中的研究数据及结果不存在篡改、剽窃、抄袭、伪造等学术不端行为，并愿意承担因学术不端行为所带来的一切后果和法律责任。
+\par \boxcheck:\hspace{0.5em} 文中依法引用他人的成果，均已做出明确标注或得到许可。
+\par \boxcheck:\hspace{0.5em} 论文内容未包含法律意义上已属于他人的任何形式的研究成果，也不包含本人已用于其他学位申请的论文或成果。
+\par \boxcheck:\hspace{0.5em} 与本人一同工作的合作者对此研究工作所做的任何贡献均已在学位论文中作了明确的说明并表示了谢意。
 \par~特此声明。},
     {authorization} {关于学位论文使用权的说明},
     {authorization_clause} {本人完全了解北京理工大学有关保管、使用学位论文的规定，其中包括：
@@ -931,7 +953,6 @@
 \RequirePackage{listings}
 \RequirePackage{enumitem}
 \RequirePackage{fmtcount}
-\RequirePackage{stmaryrd}
 %    \end{macrocode}
 %
 % 抑制 \pkg{hyperref} 中对 |\hskip| 的 warning 信息。
@@ -1858,22 +1879,17 @@
               \heiti \zihao{-4}
               \scalebox{1.1}\BigStar{}\hspace{4pt} \c_@@_label_special_type_tl\\
 
-              \makebox[1em][l]
               {
-                \makebox[1pt][l]{\zihao{4}$\boxempty$}
-                \bool_if:NT \l_@@_value_cross_research_bool {
-                  $\checkmark$
-                }
+                \zihao{4}
+                \bool_if:NTF \l_@@_value_cross_research_bool {\boxcheck:} {\boxempty:}
               }
-              \hspace{3pt}\c_@@_label_cross_research_tl\\
-              \makebox[1em][l]
+              \hspace{1pt}\c_@@_label_cross_research_tl\\
+
               {
-                \makebox[1pt][l]{\zihao{4}$\boxempty$}
-                \bool_if:NT \l_@@_value_international_student_ugp_bool {
-                  $\checkmark$
-                }
+                \zihao{4}
+                \bool_if:NTF \l_@@_value_international_student_ugp_bool {\boxcheck:} {\boxempty:}
               }
-              \hspace{3pt}\c_@@_label_international_student_ugp_tl
+              \hspace{1pt}\c_@@_label_international_student_ugp_tl
             \end{minipage}
           }
           \end{flushright}

--- a/templates/reading-report/chapters/1_chapter1.tex
+++ b/templates/reading-report/chapters/1_chapter1.tex
@@ -96,6 +96,11 @@
       楷体         & {\kaishu{}楷书}      & \textbf{\kaishu{}楷书粗体} & \textit{\kaishu{}斜体楷体} &  \colorbox{gray}{\textbf{\textit{\kaishu{}楷书粗斜体}}}    \\
     Serif(Roman/Normal)      &    Regular    &  \textbf{Bold}  &    \textit{Italic}    &     \textbf{\textit{Bold Italic}}    \\
     Sans Serif &  \textsf{Regular}       &  \textbf{\textsf{Bold}}    &  \textit{\textsf{Bold}}   &    \textbf{\textit{\textsf{Bold}}}   \\
+    % 有些字体缺少特定变体，LaTeX会抛出警告，同时尽量替换为相近变体。
+    % 若编译结果能接受，可忽略之。
+    % 例如此处Typewriter代表的Latin Modern Sans Typewriter（lmtt）字体没有bold extended italic（bx/it）变体，
+    % 所以`\textbf{\textit{\texttt{…}}}`会被替换为bold slant（b/sl）变体，并引发如下警告。（其中TU指字体编码）
+    % Font shape `TU/lmtt/bx/it' in size <…> not available. Font shape `TU/lmtt/b/sl' tried instead.
     Typewriter &  \texttt{Regular}       &  \textbf{\texttt{Bold}}    &  \textit{\texttt{Bold}}   &    \textbf{\textit{\texttt{Bold}}}   \\
     Math       &   $\mathnormal{Regular} \mathrm{Roman}$  & $\mathbf{Bold}$   &    $\mathit{Italic}$    &  $\mathbf{\mathit{Bold Italic}}$    \\ \bottomrule
     \end{tabular}

--- a/templates/undergraduate-thesis/chapters/1_chapter1.tex
+++ b/templates/undergraduate-thesis/chapters/1_chapter1.tex
@@ -96,6 +96,11 @@
       楷体         & {\kaishu{}楷书}      & \textbf{\kaishu{}楷书粗体} & \textit{\kaishu{}斜体楷体} &  \colorbox{gray}{\textbf{\textit{\kaishu{}楷书粗斜体}}}    \\
     Serif(Roman/Normal)      &    Regular    &  \textbf{Bold}  &    \textit{Italic}    &     \textbf{\textit{Bold Italic}}    \\
     Sans Serif &  \textsf{Regular}       &  \textbf{\textsf{Bold}}    &  \textit{\textsf{Bold}}   &    \textbf{\textit{\textsf{Bold}}}   \\
+    % 有些字体缺少特定变体，LaTeX会抛出警告，同时尽量替换为相近变体。
+    % 若编译结果能接受，可忽略之。
+    % 例如此处Typewriter代表的Latin Modern Sans Typewriter（lmtt）字体没有bold extended italic（bx/it）变体，
+    % 所以`\textbf{\textit{\texttt{…}}}`会被替换为bold slant（b/sl）变体，并引发如下警告。（其中TU指字体编码）
+    % Font shape `TU/lmtt/bx/it' in size <…> not available. Font shape `TU/lmtt/b/sl' tried instead.
     Typewriter &  \texttt{Regular}       &  \textbf{\texttt{Bold}}    &  \textit{\texttt{Bold}}   &    \textbf{\textit{\texttt{Bold}}}   \\
     Math       &   $\mathnormal{Regular} \mathrm{Roman}$  & $\mathbf{Bold}$   &    $\mathit{Italic}$    &  $\mathbf{\mathit{Bold Italic}}$    \\ \bottomrule
     \end{tabular}


### PR DESCRIPTION
Resolves #434

模板中有些字体警告，此PR修复了一部分，被给剩下的加了注释。

另外，手册也有字体警告（缺失“数学+小型大写字母+倾斜”），此PR没有处理，因为一般人遇不到，也没有太大影响。

## 详细修改

- Drop `stmaryrd` (The St Mary’s Road symbol font)

  这个字体用于硕博模板的选框，但它只有固定几种大小，会在莫名其妙的地方引发字体警告，而且影响本科模板了。

  https://github.com/BITNP/BIThesis/issues/434#issuecomment-2033422554

- Replace `\boxempty` (from  St Mary’s Road) with `\square` (from AMS)

- Add a new `\boxcheck:` in `originality_clause`

  [Word 模板](https://grd.bit.edu.cn/xwgz/xwgz2/wjxz_xwgz/b119746.htm)有，之前缺了。

  ![图片](https://github.com/BITNP/BIThesis/assets/73375426/430239b1-af10-4514-acda-6d4662d8b3c2)

- Amend spaces

- doc: font shape warnings

## 与之前 BIThesis 对比

![图片](https://github.com/BITNP/BIThesis/assets/73375426/05956e58-cdb4-40af-815e-2dd0dfb1df96)

![图片](https://github.com/BITNP/BIThesis/assets/73375426/cb52fe40-45fe-4583-9e11-0e2df44eedac)

![图片](https://github.com/BITNP/BIThesis/assets/73375426/2784653e-0bb0-44da-a0e5-5eae1462f93c)

## 与 Word 模板对比

![图片](https://github.com/BITNP/BIThesis/assets/73375426/e7daefb3-bbb2-44ec-8f6f-85fa9ad6c1e3)

## 参考

- [What are the different kinds of boxes in (La)TeX? - TeX - LaTeX Stack Exchange](https://tex.stackexchange.com/questions/83930/what-are-the-different-kinds-of-boxes-in-latex)
- [enumerate - How to create checkbox todo list? - TeX - LaTeX Stack Exchange](https://tex.stackexchange.com/questions/247681/how-to-create-checkbox-todo-list)