### PR TITLE
feat: control separation around float environment

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1313,6 +1313,21 @@ hideLinks = (*(true)|false*)
 
 \end{function}
 
+\begin{function}[added=2024-04-09]{misc/floatSeparation}
+\begin{bitsyntax}[emph={[1]floatSeparation}]
+floatSeparation = (*(0)|\marg{实数}*)
+\end{bitsyntax}
+
+ \textit{此选项一般不需要用户自行修改。}
+
+ 此选项用于调整浮动体与正文之间的距离，距离单位为行距，允许小数与负数。默认值为0倍行距，即不调整。
+
+ 默认值已考虑本科生毕业设计对空行的要求。
+
+ \textit{请在导言区使用此选项。}
+
+\end{function}
+
 \subsubsection{常量名称覆盖}
 \label{sec:const}
 

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -721,6 +721,9 @@
     autoref / table .initial:n = {\g_@@_const_autoref_tab_tl},
     autoref / equ .tl_set:N = \equationautorefname,
     autoref / equ .initial:n = {\g_@@_const_autoref_equ_tl},
+    % 浮动体与正文之间的距离
+    floatSeparation .tl_set:N = \l_@@_misc_float_separation_tl,
+    floatSeparation .initial:n = {0},
   }
 %    \end{macrocode}
 %    
@@ -1005,7 +1008,10 @@
 % 根据学校的要求，在本科生模板图片前后加上一行空白。
 %    \begin{macrocode}
 \@@_if_bachelor_thesis:T {
+  % 浮动体位于正文中间时，调整浮动体与上下正文之间的距离，即"前后加上一行空白"
   \setlength{\intextsep}{1.80\baselineskip plus 0.2\baselineskip minus 0.2\baselineskip}
+  % 浮动体位于页面顶部或底部时，调整浮动体与正文之间的距离，后或前加上一行空白
+  \setlength{\textfloatsep}{1.80\baselineskip plus 0.2\baselineskip minus 0.2\baselineskip}
 }
 %    \end{macrocode}
 %
@@ -1548,8 +1554,18 @@
 %    \begin{macrocode}
 \@@_if_graduate:TF {
   \tl_set:Nn \g_@@_label_divide_char_tl {.}
+  % 研究生模板要求 "图序和图题间空1个中文字距"
+  \captionsetup[figure]{font=small,labelsep=quad}
+  % 研究生模板要求 "表序和题目间空1个中文字距"
+  \captionsetup[table]{font=small,labelsep=quad}
+  % 其它 caption 也参照上述格式
+  \captionsetup[lstlisting]{font=small,labelsep=quad}
 } {
   \tl_set:Nn \g_@@_label_divide_char_tl {-}
+  % 本科生模板无 caption 字距要求
+  \captionsetup[figure]{font=small,labelsep=space}
+  \captionsetup[table]{font=small,labelsep=space}
+  \captionsetup[lstlisting]{font=small,labelsep=space}
 }
 %    \end{macrocode}
 % 
@@ -1558,11 +1574,9 @@
 %    \begin{macrocode}
 % 图片：五号字。
 \cs_set:Npn \thefigure {\thechapter\g_@@_label_divide_char_tl\arabic{figure}}
-\captionsetup[figure]{font=small,labelsep=space}
 
 % 表格：五号字。
 \cs_set:Npn \thetable {\thechapter\g_@@_label_divide_char_tl\arabic{table}}
-\captionsetup[table]{font=small,labelsep=space}
 
 % equation
 \cs_set:Npn \theequation {\thechapter\g_@@_label_divide_char_tl\arabic{equation}}
@@ -1577,9 +1591,10 @@
   \setlength{\abovedisplayshortskip}{\l_@@_style_math_above_display_skip_dim}
   \setlength{\belowdisplayskip}{\l_@@_style_math_below_display_skip_dim}
   \setlength{\belowdisplayshortskip}{\l_@@_style_math_below_display_skip_dim}
-  %
+  % 调整浮动体与文字之间的距离
+  \addtolength{\intextsep}{\l_@@_misc_float_separation_tl\baselineskip}
+  \addtolength{\textfloatsep}{\l_@@_misc_float_separation_tl\baselineskip}
 }
-\captionsetup[lstlisting]{font=small,labelsep=space}
 %    \end{macrocode}
 % \end{macro}
 % 


### PR DESCRIPTION
- 增加调整浮动体与正文间距的选项
- 本科生模板补充当图片或表格在页面顶端或底端时的空行
- 研究生模板要求图表序和图表题之间空1个中文字距
- 更新文档

## 效果

### 增加调整浮动体与正文间距的选项
- 当浮动体位于顶端和底端时仅改变浮动体与正文的间距
- misc / floatSeparation = 0 即保持默认
![image](https://github.com/BITNP/BIThesis/assets/62272084/c9ae6c36-d559-490e-856f-ae9316914804)
![image](https://github.com/BITNP/BIThesis/assets/62272084/43e4e92b-4324-47ed-9ab9-8cb2489cdee0)
- misc / floatSeparation = -1
![image](https://github.com/BITNP/BIThesis/assets/62272084/3bf69bbb-af30-4f6b-bd69-deea63cf73fe)
![image](https://github.com/BITNP/BIThesis/assets/62272084/9ebad642-9065-409f-8eb8-a7fbe0411fb8)
- misc / floatSeparation = 2.5
![image](https://github.com/BITNP/BIThesis/assets/62272084/06747034-a675-4c43-9e75-cc4ffc844118)
![image](https://github.com/BITNP/BIThesis/assets/62272084/572012f8-a69a-4e9c-bf79-2810e5988d98)

### 本科生模板补充当图片或表格在页面顶端或底端时的空行
- 修改前
![image](https://github.com/BITNP/BIThesis/assets/62272084/cdf3e43c-604a-429c-ac3e-8c0782f33854)
- 修改后
![image](https://github.com/BITNP/BIThesis/assets/62272084/430ac550-8a74-4b0b-9ade-c6469a2ee361)

### 研究生模板要求图表序和图表题之间空1个中文字距
![image](https://github.com/BITNP/BIThesis/assets/62272084/f75bc46d-166f-4bb3-a853-548964aca167)
- `lstlisting` 也相应处理

### 更新文档
![image](https://github.com/BITNP/BIThesis/assets/62272084/91415f82-8f4d-46b0-854f-1bc4db4ca456)
