### PR TITLE
fix: support the `algorithm2e` package

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1532,7 +1532,12 @@ addTOC = (*<(true)|false>*)
   (*\meta{证明过程}*)
 \end{proof}
 \end{bitsyntax}
+
   一系列预定义的数学环境。具体含义见表~\ref{tab:theorem}。
+
+  其中提供了算法环境 |algo|，但模板也适配了
+  \href{https://www.overleaf.com/learn/latex/Algorithms}{Overleaf}
+  介绍的 |algorithm|+X 方式或 |algorithm2e| 方式，您引入相关宏包即可使用。只需注意这三种方法并不兼容，而且采用 |algorithm2e| 方式时，要加上选项 |algochapter| 才能按学校要求分章编号（例如 |\usepackage[ruled,algochapter]{algorithm2e}|）。
 \end{function}
 
 \begin{table}[]

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -692,11 +692,16 @@
     tabularFontSize .initial:n = {5},
     arialFont .tl_set:N = \l_@@_misc_arial_font_path_tl,
     autoref / algo .code:n = {
-      % 定义算法的 autoref
-      \tl_set:Nn \algorithmautorefname {#1}
-      % 定义算法标题
       \AtBeginDocument{
+        % 定义算法标题
+        % 针对 algorithm 宏包
         \tl_set:Nn \ALG@name {#1}
+        % 针对 algorithm2e 宏包
+        \tl_set:Nn \algorithmcfname {#1}
+
+        % 定义算法的 autoref
+        % algorithm2e 宏包会覆写它，所以我们必须AtBeginDocument时再修改
+        \tl_set:Nn \algorithmautorefname {#1}
       }
     },
     autoref / algo .initial:n = {\g_@@_const_autoref_algo_tl},
@@ -1596,8 +1601,16 @@
   \cs_gset:Npn \lstlistingname {\c_@@_label_code_tl}
   
   % 算法变成「章节号-序号」
+  % 针对 algorithm 宏包
   \cs_gset:Npn \thealgorithm
   {\thechapter\g__bithesis_label_divide_char_tl\arabic{algorithm}}
+  % 针对 algorithm2e 宏包
+  % 为了减少修改，我们只适配按章编号（algochapter）的情况。
+  \@ifpackagewith{algorithm2e}{algochapter}{
+    % 名字中的“cf”是指其作者 Christophe Fiorio。
+    \cs_gset:Npn \thealgocf
+    {\thechapter\g__bithesis_label_divide_char_tl\arabic{algocf}}
+  }{}
   
   % 默认的情况下，保留公式和上下文的一定间距。（会比 Word 稍宽一些）
   \setlength{\abovedisplayskip}{\l_@@_style_math_above_display_skip_dim}


### PR DESCRIPTION
Based on [captions - Modifying the algorithm name in algorithm2e - TeX - LaTeX Stack Exchange](https://tex.stackexchange.com/questions/541495/modifying-the-algorithm-name-in-algorithm2e/541499#541499)

Resolves #454

Relates-to: #445

## 效果

无论是否使用`algorithm2e`，标题、autoref、分隔符都正常，并且不影响模板原有的`algo`。

### 硕博 + `algorithm2e` ⇒ 汉字 + 点

![图片](https://github.com/BITNP/BIThesis/assets/73375426/e653ad03-58cb-4a35-8c6c-6636bf959f5e)

```latex
\usepackage[ruled,algochapter]{algorithm2e}

\begin{document}

\mainmatter

\begin{algo}
  啊
\end{algo}

\begin{algorithm} 
  \SetKwData{Left}{left}\SetKwData{This}{this}\SetKwData{Up}{up} \SetKwFunction{Union}{Union}\SetKwFunction{FindCompress}{FindCompress} \SetKwInOut{Input}{输入}\SetKwInOut{Output}{输出}

  \Input{A bitmap $Im$ of size $w\times l$}
  \Output{A partition of the bitmap}
  \BlankLine

  \emph{special treatment of the first line}\;
  \For{$i\leftarrow 2$ \KwTo $l$}{
    \lForEach{element $e$ of the line $i$}{\FindCompress{p}}
  }
  \caption{disjoint decomposition}
  \label{algo:disjdecomp}
\end{algorithm}

Autoref: 左\autoref{algo:disjdecomp}右

Ref: 左\ref{algo:disjdecomp}右

\end{document}
```

### 本科 + `algorithm` ⇒ 汉字 + 横线

![图片](https://github.com/BITNP/BIThesis/assets/73375426/d929f567-18ee-4932-817c-b4ecdc34957e)

```latex
\usepackage{algorithm}
\usepackage{algpseudocode}

\begin{document}

\mainmatter

\begin{algo}
  啊
\end{algo}

\begin{algorithm}
  \caption{An algorithm with caption}\label{alg:cap}
  \begin{algorithmic}
    \Require $n \geq 0$
    \Ensure $y = x^n$
    \State $y \gets 1$
    \State $X \gets x$
    \State $N \gets n$
    \While{$N \neq 0$}
    \If{$N$ is even}
    \State $X \gets X \times X$
    \State $N \gets \frac{N}{2}$  \Comment{This is a comment}
    \ElsIf{$N$ is odd}
    \State $y \gets y \times X$
    \State $N \gets N - 1$
    \EndIf
    \EndWhile
  \end{algorithmic}
\end{algorithm}

Autoref: 左\autoref{alg:cap}右

Ref: 左\ref{alg:cap}右

\end{document}
```

### 本科英文 + `algorithm2e` ⇒ 英文 + 横线

![图片](https://github.com/BITNP/BIThesis/assets/73375426/e4e40d9a-2530-44d0-879d-539b9aafed80)


```latex
\usepackage[ruled,algochapter]{algorithm2e}

\begin{document}

\mainmatter

\begin{algo}
  啊
\end{algo}


\begin{algorithm} 
  \SetKwData{Left}{left}\SetKwData{This}{this}\SetKwData{Up}{up} \SetKwFunction{Union}{Union}\SetKwFunction{FindCompress}{FindCompress} \SetKwInOut{Input}{输入}\SetKwInOut{Output}{输出}

  \Input{A bitmap $Im$ of size $w\times l$}
  \Output{A partition of the bitmap}
  \BlankLine

  \emph{special treatment of the first line}\;
  \For{$i\leftarrow 2$ \KwTo $l$}{
    \lForEach{element $e$ of the line $i$}{\FindCompress{p}}
  }
  \caption{disjoint decomposition}
  \label{algo:disjdecomp}
\end{algorithm}

Autoref: 左\autoref{algo:disjdecomp}右

Ref: 左\ref{algo:disjdecomp}右

\end{document}
```