### PR TITLE
refactor: 删除表格中无用的`\zihao{5}`

### DIFF
--- a/templates/paper-translation/chapters/1_chapter1.tex
+++ b/templates/paper-translation/chapters/1_chapter1.tex
@@ -48,7 +48,6 @@
 
 \begin{table}[htbp]
   \linespread{1.5}
-  \zihao{5}
   \centering
   \caption{统计表}\label{统计表}
   \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}}

--- a/templates/reading-report/chapters/1_chapter1.tex
+++ b/templates/reading-report/chapters/1_chapter1.tex
@@ -45,7 +45,6 @@
 % 三线表
 \begin{table}[htbp]
   \linespread{1.5}
-  \zihao{5}
   \centering
   \caption{统计表}\label{统计表}
   \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}} \toprule
@@ -85,7 +84,6 @@
 
 \begin{table}[htb]
     \linespread{1.5}
-    \zihao{5}
     \centering
     \caption{字体效果表格}
     \begin{tabular}{@{}lllll@{}}

--- a/templates/undergraduate-thesis-en/chapters/2_chapter2.tex
+++ b/templates/undergraduate-thesis-en/chapters/2_chapter2.tex
@@ -17,7 +17,6 @@ The philosophy behind the method is to create a high-quality information channel
 
 \begin{table}[htbp]
   \linespread{1.5}
-  \zihao{5}
   \centering
   \caption{Range of variables in design of experiment}\label{tab:1}
   \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}}

--- a/templates/undergraduate-thesis/chapters/1_chapter1.tex
+++ b/templates/undergraduate-thesis/chapters/1_chapter1.tex
@@ -45,7 +45,6 @@
 % 三线表
 \begin{table}[htbp]
   \linespread{1.5}
-  \zihao{5}
   \centering
   \caption{统计表}\label{统计表}
   \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}} \toprule
@@ -85,7 +84,6 @@
 
 \begin{table}[htb]
     \linespread{1.5}
-    \zihao{5}
     \centering
     \caption{字体效果表格}
     \begin{tabular}{@{}lllll@{}}


### PR DESCRIPTION
9e58b8b 在`tabular`环境开头改了字号，所以在`tabular`外设置字号不会影响表格内部。另外`\captionsetup[table]{font=small,…}`也将标题设为了小五号。

模板提供了`misc/tabularFontSize`统一设置`tabular`和`tabular*`的字号，默认是`5`。

例如，下面设置`\zihao{0}`，但并未改为初号。

![图片](https://github.com/BITNP/BIThesis/assets/73375426/8b2659d8-d6dc-4873-af87-90b82521ce81)
