### PR TITLE
fix: 改正`tabularx`环境中的字号

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1489,6 +1489,7 @@
   % preamble 中也不会有影响。
   \AtBeginEnvironment{tabular}{\zihao{\l_@@_misc_tabular_font_size_tl}}
   \AtBeginEnvironment{tabular*}{\zihao{\l_@@_misc_tabular_font_size_tl}}
+  \AtBeginEnvironment{tabularx}{\zihao{\l_@@_misc_tabular_font_size_tl}}
 }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
[`tabularx`](https://www.ctan.org/pkg/tabularx)基本是指定列宽的唯一选择——`tabular*`只能指定空白宽度。它由 The LaTeX Project Team 维护，也被 [Overleaf 文档](https://www.overleaf.com/learn/latex/Tables)收录了，比较著名，应当适配。

## 示例

```latex
\documentclass[type=bachelor]{bithesis}

\BITSetup{
  misc = {
    tabularFontSize = 0,
  }
}

\usepackage{tabularx}

\begin{document}

% 钩子挂在这里了，必须有。
\frontmatter

\begin{table}[ht]
  \begin{tabularx}{\textwidth}{|X|}
    \hline
    初号字 Font size 0 \\
    \hline
  \end{tabularx}
\end{table}

正文

{\zihao{0} 初号字 Font size 0}

\end{document}
```

![图片](https://github.com/BITNP/BIThesis/assets/73375426/0b14bdce-65c8-4a9e-8325-e95ab7d69d15)
