### PR TITLE
refactor: 只在按章编号时适配algorithm宏包

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1535,9 +1535,7 @@ addTOC = (*<(true)|false>*)
 
   一系列预定义的数学环境。具体含义见表~\ref{tab:theorem}。
 
-  其中提供了算法环境 |algo|，但模板也适配了
-  \href{https://www.overleaf.com/learn/latex/Algorithms}{Overleaf}
-  介绍的 |algorithm|+X 方式或 |algorithm2e| 方式，您引入相关宏包即可使用。只需注意这三种方法并不兼容，而且采用 |algorithm2e| 方式时，要加上选项 |algochapter| 才能按学校要求分章编号（例如 |\usepackage[ruled,algochapter]{algorithm2e}|）。
+  其中提供了算法环境 |algo|，但模板也适配了一些更专业的宏包，请参考 \ref{sec:algorithm}。
 \end{function}
 
 \begin{table}[]
@@ -1736,6 +1734,37 @@ addTOC = (*<(true)|false>*)
 \end{function}
 
 \section{常见问题和疑难解答}
+
+\subsection{如何排版算法（伪代码）？} \label{sec:algorithm}
+
+有以下三种互不兼容的方式。
+
+\begin{itemize}
+  \item |algorithm|+X 方式
+
+  引入 |algorithm| 宏包时，要加上选项 |chapter| 才能按学校要求分章编号，示例如下。
+
+\begin{bitsyntax}[emph={[1]chapter}]
+\usepackage[chapter]{algorithm}
+\usepackage{algorithmic} % 也可替换为 algpseudocode 或 algcompatible
+\end{bitsyntax}
+
+  使用示例请参考 \href{https://www.overleaf.com/learn/latex/Algorithms}{Algorithms - Overleaf 文档}。
+
+  \item |algorithm2e| 方式
+
+  引入宏包时，要加上选项 |algochapter| 才能按学校要求分章编号，示例如下。
+
+\begin{bitsyntax}[emph={[1]algochapter}]
+\usepackage[ruled, algochapter]{algorithm2e}
+\end{bitsyntax}
+
+  使用示例请参考 \href{https://www.overleaf.com/learn/latex/Algorithms#The_algorithm2e_package}{Algorithms - Overleaf 文档的 The |algorithm2e| package 一节}。
+
+  \item 使用模板提供的 |algo| 环境
+
+  这是表~\ref{tab:theorem}中的数学环境之一，不额外依赖宏包，但功能有限，基本只支持编号。
+\end{itemize}
 
 \subsection{为什么我的研究生模板开头有间隔的空白页？}
 

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1602,11 +1602,13 @@
   \cs_gset:Npn \lstlistingname {\c_@@_label_code_tl}
   
   % 算法变成「章节号-序号」
+  % 为了减少修改，我们只适配按章编号的情况。
   % 针对 algorithm 宏包
-  \cs_gset:Npn \thealgorithm
-  {\thechapter\g__bithesis_label_divide_char_tl\arabic{algorithm}}
+  \@ifpackagewith{algorithm}{chapter}{
+    \cs_gset:Npn \thealgorithm
+    {\thechapter\g__bithesis_label_divide_char_tl\arabic{algorithm}}
+  }
   % 针对 algorithm2e 宏包
-  % 为了减少修改，我们只适配按章编号（algochapter）的情况。
   \@ifpackagewith{algorithm2e}{algochapter}{
     % 名字中的“cf”是指其作者 Christophe Fiorio。
     \cs_gset:Npn \thealgocf


### PR DESCRIPTION
Resolves #467

目前没在`*.tex`加注释。

![图片](https://github.com/BITNP/BIThesis/assets/73375426/fbbffdc1-2ca8-45c1-a941-60e9fd41f620)
