### PR TITLE
refactor: 删除markdown宏包

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -3978,7 +3978,6 @@
 % \RequirePackage{etoolbox}
 \RequirePackage{dirtree}
 \RequirePackage{metalogo}
-\RequirePackage[tightLists=false]{markdown}
 \RequirePackage{caption}
 \RequirePackage{tikz}
 \usetikzlibrary{positioning}
@@ -3990,12 +3989,6 @@
  % 设置列表无间隔
 \usepackage{enumitem}
 \setlist{nosep}
-
-\markdownSetup{
-  renderers = {
-    link = {\href{#2}{#1}},
-  }
-}
 
 \hypersetup{
   pdflang     = zh-CN,


### PR DESCRIPTION
在TeX Live 2024，它会导致`bithesis.luabridge.lua`，而宏包本身似乎完全没用。

https://github.com/BITNP/BIThesis/pull/414#issuecomment-2003960541
