### PR TITLE
微调本科模板表格格式

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1332,6 +1332,21 @@ floatSeparation = (*(0)|\marg{实数}*)
 
 \end{function}
 
+\begin{function}[added=2024-04-30]{misc/tabularRowSeparation}
+\begin{bitsyntax}[emph={[1]tabularRowSeparation}]
+tabularRowSeparation = (*(1)|\marg{正实数}*)
+\end{bitsyntax}
+
+  \textit{此选项一般不需要用户自行修改。}
+
+  此选项用于调整表格各行之间的距离，允许小数。默认值为1，相当于不调整。
+
+  学校没有明文规定，不过设为1.25更接近本科Word模板实作，设为1.6更接近硕博Word模板实作。
+
+  \textit{请在导言区使用此选项。}
+
+\end{function}
+
 \subsubsection{常量名称覆盖}
 \label{sec:const}
 

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1550,14 +1550,21 @@
   \@@_if_thesis_english:TF {
     \setlength{\belowcaptionskip}{9pt}
   } {
-    % 为了满足 “前后一行空白的问题”，需要删除 Caption 下方的间距。
+    % 为了满足 “前后一行空白的问题”，需要删除 caption 下方的间距。
     % 详见 `caption` 宏包手册和
     % https://github.com/CTeX-org/forum/issues/86
     % 
     % 这里实际的 skip 在 15pt 左右，但是全部移除会导致当图片置于页面顶部时，
     % 图片与上方的间距过小，因此这里只移除 5pt。
-    % 当然，这样会导致文本间的图片的 Caption 下方的间距微微大于一行。
+    % 当然，这样会导致文本间的图片的 caption 下方的间距微微大于一行。
+    %
+    % 至于表格，虽然其caption位置在上方（而图片是在下方），
+    % 但 `caption` 宏包已考虑这种区别，统一设置 `belowskip` 即可。
     \captionsetup{belowskip=-5pt}
+
+    % 此外在浮动体内部，调整表格 caption 和表格本体间的距离。
+    % 本来默认有一定空隙，现改为紧贴，这样更接近Word模板实作。
+    \captionsetup[table]{skip=5pt}
   }
 } {
   % 而研究生模板不存在这个问题。

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -733,9 +733,11 @@
     autoref / table .initial:n = {\g_@@_const_autoref_tab_tl},
     autoref / equ .tl_set:N = \equationautorefname,
     autoref / equ .initial:n = {\g_@@_const_autoref_equ_tl},
-    % 浮动体与正文之间的距离
+    % 浮动体相关的各种间距
     floatSeparation .tl_set:N = \l_@@_misc_float_separation_tl,
     floatSeparation .initial:n = {0},
+    tabularRowSeparation .tl_set:N = \l_@@_misc_tabular_row_separation_tl,
+    tabularRowSeparation .initial:n = {1},
   }
 %    \end{macrocode}
 %    
@@ -1623,6 +1625,8 @@
   % 调整浮动体与文字之间的距离
   \addtolength{\intextsep}{\l_@@_misc_float_separation_tl\baselineskip}
   \addtolength{\textfloatsep}{\l_@@_misc_float_separation_tl\baselineskip}
+  % 调整表格各行之间的距离
+  \cs_set:Npn \arraystretch {\l_@@_misc_tabular_row_separation_tl}
 }
 %    \end{macrocode}
 % \end{macro}

--- a/templates/paper-translation/chapters/1_chapter1.tex
+++ b/templates/paper-translation/chapters/1_chapter1.tex
@@ -47,7 +47,6 @@
 \textcolor{blue}{\underline{\underline{表-示例：（阅后删除此段）}}}
 % 三线表
 \begin{table}[htbp]
-  \linespread{1.5}
   \centering
   \caption{统计表}\label{统计表}
   \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}} \toprule

--- a/templates/paper-translation/chapters/1_chapter1.tex
+++ b/templates/paper-translation/chapters/1_chapter1.tex
@@ -45,19 +45,18 @@
 \end{figure}
 
 \textcolor{blue}{\underline{\underline{表-示例：（阅后删除此段）}}}
-
+% 三线表
 \begin{table}[htbp]
   \linespread{1.5}
   \centering
   \caption{统计表}\label{统计表}
-  \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}}
-    \hline
-    项目    & 产量    & 销量    & 产值   & 比重    \\ \hline
+  \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}} \toprule
+    项目    & 产量    & 销量    & 产值   & 比重    \\ \midrule
     手机    & 1000  & 10000 & 500  & 50\%  \\
     计算机   & 5500  & 5000  & 220  & 22\%  \\
-    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \hline
-    合计    & 17600 & 16000 & 1000 & 100\% \\ \hline
-  \end{tabular}
+    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
+    合计    & 17600 & 16000 & 1000 & 100\% \\ \bottomrule
+    \end{tabular}
 \end{table}
 
 \textcolor{blue}{公式标注应于该公式所在行的最右侧。对于较长的公式只可在符号处（+、-、*、/、$\leqslant$ $\geqslant$ 等）转行。在文中引用公式时，在标号前加“式”，如式（1-2）。阅后删除此

--- a/templates/paper-translation/main.tex
+++ b/templates/paper-translation/main.tex
@@ -64,7 +64,11 @@
     % 1. 不想在系统中安装 Times New Roman。
     % 2. 在 Linux/macOS 下遇到 `\textsc` 无法正常显示的问题。
     % betterTimesNewRoman = true,
-  }
+  },
+  misc = {
+    % 微调表格行间距
+    tabularRowSeparation = 1.25,
+  },
 }
 
 % 大部分关于参考文献样式的修改，都可以通过此处的选项进行配置。

--- a/templates/reading-report/chapters/1_chapter1.tex
+++ b/templates/reading-report/chapters/1_chapter1.tex
@@ -44,7 +44,6 @@
 \textcolor{blue}{\underline{\underline{表-示例：（阅后删除此段）}}}
 % 三线表
 \begin{table}[htbp]
-  \linespread{1.5}
   \centering
   \caption{统计表}\label{统计表}
   \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}} \toprule
@@ -83,7 +82,6 @@
 % 行：宋体、黑体、楷体、Serif、Sans Serif、Typewriter、Math
 
 \begin{table}[htb]
-    \linespread{1.5}
     \centering
     \caption{字体效果表格}
     \begin{tabular}{@{}lllll@{}}

--- a/templates/reading-report/chapters/1_chapter1.tex
+++ b/templates/reading-report/chapters/1_chapter1.tex
@@ -48,10 +48,10 @@
   \centering
   \caption{统计表}\label{统计表}
   \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}} \toprule
-    项目    & 产量    & 销量    & 产值   & 比重    \\ \hline
+    项目    & 产量    & 销量    & 产值   & 比重    \\ \midrule
     手机    & 1000  & 10000 & 500  & 50\%  \\
     计算机   & 5500  & 5000  & 220  & 22\%  \\
-    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\
+    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
     合计    & 17600 & 16000 & 1000 & 100\% \\ \bottomrule
     \end{tabular}
 \end{table}

--- a/templates/reading-report/main.tex
+++ b/templates/reading-report/main.tex
@@ -54,7 +54,11 @@
     headline = 本科生读书报告,
     % 开启 Windows 平台下的中易宋体伪粗体。
     % windowsSimSunFakeBold = true,
-  }
+  },
+  misc = {
+    % 微调表格行间距
+    tabularRowSeparation = 1.25,
+  },
 }
 
 % 使用 listings 宏包进行代码块使用，并使用了预定义的样式，

--- a/templates/undergraduate-thesis-en/chapters/2_chapter2.tex
+++ b/templates/undergraduate-thesis-en/chapters/2_chapter2.tex
@@ -21,7 +21,7 @@ The philosophy behind the method is to create a high-quality information channel
   \caption{Range of variables in design of experiment}\label{tab:1}
   \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}}
     \toprule
-       & \textbf{AAA}    & \textbf{BBB}    & \textbf{CCC}   & \textbf{DDD}    \\ \hline
+       & \textbf{AAA}    & \textbf{BBB}    & \textbf{CCC}   & \textbf{DDD}    \\ \midrule
     Alpha    & 1000  & 10000 & 500  & 50\%  \\
     Beta   & 5500  & 5000  & 220  & 22\%  \\
     Gamma & 1100  & 1000  & 280  & 28\%  \\

--- a/templates/undergraduate-thesis-en/chapters/2_chapter2.tex
+++ b/templates/undergraduate-thesis-en/chapters/2_chapter2.tex
@@ -16,7 +16,6 @@ This chapter presents a method for comprehensively identifying a set of customer
 The philosophy behind the method is to create a high-quality information channel that runs directly between customers in the target market and the developers of the product. This philosophy is built on the premise that those who directly control the details of the product, including  the  engineers  and  industrial  designers,  must  interact  with customers  and experience the use environment of the product. Without this direct experience, technical trade-offs are not likely to be made correctly, innovative solutions to customer needs may never be discovered, and the development team may never develop a deep commitment to meeting customer needs. See table \ref{tab:1}
 
 \begin{table}[htbp]
-  \linespread{1.5}
   \centering
   \caption{Range of variables in design of experiment}\label{tab:1}
   \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}}

--- a/templates/undergraduate-thesis-en/main.tex
+++ b/templates/undergraduate-thesis-en/main.tex
@@ -58,7 +58,11 @@
     bibliographyIndent = false,
     % 如无必要请勿修改该项。
     % head = {自定义页眉文字}
-  }
+  },
+  misc = {
+    % 微调表格行间距
+    tabularRowSeparation = 1.25,
+  },
 }
 
 % 使用 listings 宏包进行代码块使用，并使用了预定义的样式，

--- a/templates/undergraduate-thesis/chapters/1_chapter1.tex
+++ b/templates/undergraduate-thesis/chapters/1_chapter1.tex
@@ -44,7 +44,6 @@
 \textcolor{blue}{\underline{\underline{表-示例：（阅后删除此段）}}}
 % 三线表
 \begin{table}[htbp]
-  \linespread{1.5}
   \centering
   \caption{统计表}\label{统计表}
   \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}} \toprule
@@ -83,7 +82,6 @@
 % 行：宋体、黑体、楷体、Serif、Sans Serif、Typewriter、Math
 
 \begin{table}[htb]
-    \linespread{1.5}
     \centering
     \caption{字体效果表格}
     \begin{tabular}{@{}lllll@{}}

--- a/templates/undergraduate-thesis/chapters/1_chapter1.tex
+++ b/templates/undergraduate-thesis/chapters/1_chapter1.tex
@@ -48,10 +48,10 @@
   \centering
   \caption{统计表}\label{统计表}
   \begin{tabular}{*{5}{>{\centering\arraybackslash}p{2cm}}} \toprule
-    项目    & 产量    & 销量    & 产值   & 比重    \\ \hline
+    项目    & 产量    & 销量    & 产值   & 比重    \\ \midrule
     手机    & 1000  & 10000 & 500  & 50\%  \\
     计算机   & 5500  & 5000  & 220  & 22\%  \\
-    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\
+    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
     合计    & 17600 & 16000 & 1000 & 100\% \\ \bottomrule
     \end{tabular}
 \end{table}

--- a/templates/undergraduate-thesis/main.tex
+++ b/templates/undergraduate-thesis/main.tex
@@ -64,7 +64,11 @@
     % 1. 不想在系统中安装 Times New Roman。
     % 2. 在 Linux/macOS 下遇到 `\textsc` 无法正常显示的问题。
     % betterTimesNewRoman = true,
-  }
+  },
+  misc = {
+    % 微调表格行间距
+    tabularRowSeparation = 1.25,
+  },
 }
 
 % 使用 listings 宏包进行代码块使用，并使用了预定义的样式，


### PR DESCRIPTION
#396 已注意到这一问题，当时认为不重要。昨天有同学说他们组专门提出来了，只好改一下。

具体的修改请看提交信息。

## Word模板

![图片](https://github.com/BITNP/BIThesis/assets/73375426/672aeca0-cb2b-4f5c-b25b-4d11c2972f3f)

## BIThesis新旧对比

- 表格caption不再有空隙，直接紧贴。
- 表格每行变窄一些。

只影响本科模板，且不改变表格前后间距。

![图片](https://github.com/BITNP/BIThesis/assets/73375426/cf6c7790-d47e-46a3-967a-6744ca7ba0f0)

![图片](https://github.com/BITNP/BIThesis/assets/73375426/355505ef-dc11-4257-9b28-c3c91b89a1e2)

