### PR TITLE
ci: Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
[现在的CI有几十个warnings](https://github.com/BITNP/BIThesis/actions/runs/8950271210)，大多是要求升级 Node.js 版本，只要更新即可解决。

相关文档：

- [GitHub Actions: Transitioning from Node 16 to Node 20 - The GitHub Blog](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

  > Our plan is to transition all actions to run on Node 20 by **Spring 2024**.

- [Configuration options for the dependabot.yml file - GitHub Docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

- [Deprecation notice: v3 of the artifact actions - The GitHub Blog](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

  > The deprecation of v3…, which is scheduled to take place on **June 30, 2024**. …, attempting to use a version of the actions after the deprecation date will result in a workflow failure.