### PR TITLE
fix: `misc/tabularRowSeparation`不应影响矩阵

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1236,7 +1236,7 @@ arialFont = (*\marg{字符串}*)
   在 Windows 和 MacOS 中，该字体已经安装；在 Linux 中需要用户自行安装（如果你是 WSL 用户，可参照\ref{sec:word-fonts}直接使用 Windows 下的字体）。
 \end{function}
 
-\begin{function}[added=2023-04-22]{misc/tabularFontSize}
+\begin{function}[added=2023-04-22, updated=2024-05-13]{misc/tabularFontSize}
 \begin{bitsyntax}[emph={[1]tabularFontSize}]
 tabularFontSize = (*(5)|其他字号*)
 \end{bitsyntax}
@@ -1247,6 +1247,8 @@ tabularFontSize = (*(5)|其他字号*)
 
   如果你需要临时调整表格中的字号，可以使用 |\BITSetup| 命令
   在局部范围内覆盖此选项（注意使用大括号）。
+
+  此选项影响的“表格”具体包括标准 |tabular|、|tabular*| 环境，以及 |tabularx| 和 |longtable| 宏包提供的环境。
 
 \begin{latex}
 {
@@ -1332,7 +1334,7 @@ floatSeparation = (*(0)|\marg{实数}*)
 
 \end{function}
 
-\begin{function}[added=2024-04-30]{misc/tabularRowSeparation}
+\begin{function}[added=2024-04-30, updated=2024-05-13]{misc/tabularRowSeparation}
 \begin{bitsyntax}[emph={[1]tabularRowSeparation}]
 tabularRowSeparation = (*(1)|\marg{正实数}*)
 \end{bitsyntax}
@@ -1342,6 +1344,8 @@ tabularRowSeparation = (*(1)|\marg{正实数}*)
   此选项用于调整表格各行之间的距离，允许小数。默认值为1，相当于不调整。
 
   学校没有明文规定，不过设为1.25更接近本科Word模板实作，设为1.6更接近硕博Word模板实作。
+
+  此选项影响的“表格”具体包括标准 |tabular|、|tabular*| 环境，以及 |tabularx| 宏包提供的环境。并不影响 |longtable| 宏包提供的环境，因为宏包已经调节了。
 
   \textit{请在导言区使用此选项。}
 

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1461,6 +1461,8 @@
     {\hspace{.5em}\titlerule*{.}\contentspage}
 %    \end{macrocode}
 % 
+%  \subsubsection{定义样式相关函数}
+%
 % \begin{macro}{\frontmatter}
 % 定义前置内容的页面样式。
 %    \begin{macrocode}
@@ -1481,7 +1483,7 @@
   \linespread{1.53}\selectfont
   \pagestyle{BIThesis}
   
-  % 表格内容默认使用五号字。
+  % 调整表格内容字号（默认五号）和各行之间的距离。
   % 
   % 由于这种方式会影响所有的表格，
   % 所以我们尽可能延迟这种影响。
@@ -1489,9 +1491,23 @@
   % 不过，在目前的代码实现中没有在封面
   % 之类的地方使用表格，所以目前即使放在
   % preamble 中也不会有影响。
-  \AtBeginEnvironment{tabular}{\zihao{\l_@@_misc_tabular_font_size_tl}}
-  \AtBeginEnvironment{tabular*}{\zihao{\l_@@_misc_tabular_font_size_tl}}
-  \AtBeginEnvironment{tabularx}{\zihao{\l_@@_misc_tabular_font_size_tl}}
+  %
+  % 支持标准tabular、tabular*环境和宏包tabularx、longtable。
+  \clist_map_inline:nn 
+    {tabular, tabular*, tabularx, longtable}
+    {
+      \AtBeginEnvironment {##1} {
+        % 字号只想设置表格内容，不想影响caption。
+        % 一般caption在环境之外，自然不受影响；
+        % 而longtable的caption虽在环境内，但caption宏包能正常处理。
+        \zihao{\l_@@_misc_tabular_font_size_tl}
+        % 各行间距只想影响表格，不想影响矩阵，因此也必须在钩子中设置。
+        % 另外，longtable宏包已经调节了空隙，我们就不重复调节了。
+        \str_if_eq:nnF {##1} {longtable} {
+          \cs_set:Npn \arraystretch {\l_@@_misc_tabular_row_separation_tl}
+        }
+      }
+    }
 }
 %    \end{macrocode}
 % \end{macro}
@@ -1632,8 +1648,6 @@
   % 调整浮动体与文字之间的距离
   \addtolength{\intextsep}{\l_@@_misc_float_separation_tl\baselineskip}
   \addtolength{\textfloatsep}{\l_@@_misc_float_separation_tl\baselineskip}
-  % 调整表格各行之间的距离
-  \cs_set:Npn \arraystretch {\l_@@_misc_tabular_row_separation_tl}
 }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
Fixes #498 
Relates to #501 

TODO：longtable表格上框线和caption有多余间距。

<details>
<summary>过时测试结果</summary>

下图左边将`tabularRowSeparation`设为`1.25`，右边设为`1`，可见表格受影响，而矩阵不变。

![图片](https://github.com/BITNP/BIThesis/assets/73375426/38a10a8a-fc61-45c8-aa49-e3d3363f45f2)

下图设为`1.25`，可见三种表格都能改。

![图片](https://github.com/BITNP/BIThesis/assets/73375426/13dda4a2-d091-41a2-bc41-37178ddf2e46)

</details>

## 测试

- 字号影响`tabular`、`tabular*`、`tabularx`、`longtable`的内容，不影响caption。
- 各行间距影响`tabular`、`tabular*`、`tabularx`，不影响`longtable`（它自己已改）、矩阵。

```latex
% !TeX program = xelatex
% !BIB program = biber

\documentclass[type=bachelor]{bithesis}

\BITSetup{
  misc = {
    tabularRowSeparation = 1.25,
    % tabularFontSize = 8,
  },
}

\usepackage{tabularx}
\usepackage{longtable}

\begin{document}

\frontmatter
\mainmatter

啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊

\begin{equation}
  \begin{bmatrix}
    1 & 0 \\
    1 & 0 \\
    1 & 0 \\
    1 & 0 \\
  \end{bmatrix}
\end{equation}

\begin{table}[ht]
  \centering
  \caption{Tabular}
  \begin{tabular}{*{5}{>{\centering\arraybackslash}p{5em}}}
    \toprule
    项目    & 产量    & 销量    & 产值   & 比重    \\ \midrule
    手机    & 1000  & 10000 & 500  & 50\%  \\
    计算机   & 5500  & 5000  & 220  & 22\%  \\
    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
    合计    & 17600 & 16000 & 1000 & 100\% \\ \bottomrule
  \end{tabular}
\end{table}

\begin{table}[ht]
  \centering
  \caption{Tabular*}
  \begin{tabular*}{32em}{@{\extracolsep{\fill}}ccccc}
    \toprule
    项目    & 产量    & 销量    & 产值   & 比重    \\ \midrule
    手机    & 1000  & 10000 & 500  & 50\%  \\
    计算机   & 5500  & 5000  & 220  & 22\%  \\
    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
    合计    & 17600 & 16000 & 1000 & 100\% \\ \bottomrule
  \end{tabular*}
\end{table}

\begin{table}[ht]
  \centering
  \caption{Tabularx}
  \begin{tabularx}{32em}{*{5}{>{\centering\arraybackslash}X}}
    \toprule
    项目    & 产量    & 销量    & 产值   & 比重    \\ \midrule
    手机    & 1000  & 10000 & 500  & 50\%  \\
    计算机   & 5500  & 5000  & 220  & 22\%  \\
    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
    合计    & 17600 & 16000 & 1000 & 100\% \\ \bottomrule
  \end{tabularx}
\end{table}

\begin{longtable}[ht]{ccccc}
  \caption{Long table}                 \\
  \toprule
  项目    & 产量    & 销量    & 产值   & 比重    \\
  \midrule
  \endfirsthead
  \multicolumn{5}{l}{续表}               \\
  \toprule
  项目    & 产量    & 销量    & 产值   & 比重    \\
  \midrule
  \endhead
  \midrule
  \multicolumn{5}{r}{{续下页}}            \\
  \endfoot
  \bottomrule
  \endlastfoot
  手机    & 1000  & 10000 & 500  & 50\%  \\
  计算机   & 5500  & 5000  & 220  & 22\%  \\
  笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
  合计    & 17600 & 16000 & 1000 & 100\% \\
\end{longtable}

\end{document}
```

### 不设置`tabularRowSeparation`

![图片](https://github.com/BITNP/BIThesis/assets/73375426/41dcb0e0-6914-48ce-93bc-cbdd57d155db)

### `tabularRowSeparation = 1.25`

![图片](https://github.com/BITNP/BIThesis/assets/73375426/42d3cddb-e98c-4bbd-8c07-6cb98d69dfa7)
![图片](https://github.com/BITNP/BIThesis/assets/73375426/23c2fd62-2341-416a-ac1b-ef4d419b5b88)
![图片](https://github.com/BITNP/BIThesis/assets/73375426/687c47b3-0d70-4b96-8ff3-44b8209d1e49)

### `tabularRowSeparation = 5, tabularFontSize = 8`

![图片](https://github.com/BITNP/BIThesis/assets/73375426/721deaad-1089-47a6-a8b9-09181310ee10)
