### PR TITLE
fix: parskip in abstract and tabularRowSeparation

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2671,7 +2671,7 @@
 
     \cleardoublepage
     \linespread{1.53}\selectfont
-    \setlength{\parskip}{0\baselineskip}
+    
     \@@_if_bachelor_thesis:T {
       \begin{center}
         \vspace*{-17bp}
@@ -2741,7 +2741,7 @@
 \NewDocumentEnvironment {abstractEn} {}
   {
     \linespread{1.53}\selectfont
-    \setlength{\parskip}{0\baselineskip}
+    
     \@@_if_bachelor_thesis:T {
       \begin{spacing}{0.95}
         \centering

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1494,7 +1494,7 @@
   \AtBeginEnvironment{tabular}{\zihao{\l_@@_misc_tabular_font_size_tl}\linespread{\l_@@_misc_tabular_row_separation_tl}\selectfont}
   \AtBeginEnvironment{tabular*}{\zihao{\l_@@_misc_tabular_font_size_tl}\linespread{\l_@@_misc_tabular_row_separation_tl}\selectfont}
   \AtBeginEnvironment{tabularx}{\zihao{\l_@@_misc_tabular_font_size_tl}\linespread{\l_@@_misc_tabular_row_separation_tl}\selectfont}
-  \AtBeginEnvironment{longtable}{\zihao{\l_@@_misc_tabular_font_size_tl}\linespread{\l_@@_misc_tabular_row_separation_tl}\selectfont}
+  \AtBeginEnvironment{longtable}{\zihao{\l_@@_misc_tabular_font_size_tl}}
 }
 %    \end{macrocode}
 % \end{macro}

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1489,9 +1489,12 @@
   % 不过，在目前的代码实现中没有在封面
   % 之类的地方使用表格，所以目前即使放在
   % preamble 中也不会有影响。
-  \AtBeginEnvironment{tabular}{\zihao{\l_@@_misc_tabular_font_size_tl}}
-  \AtBeginEnvironment{tabular*}{\zihao{\l_@@_misc_tabular_font_size_tl}}
-  \AtBeginEnvironment{tabularx}{\zihao{\l_@@_misc_tabular_font_size_tl}}
+  %
+  % 调整表格各行之间的距离
+  \AtBeginEnvironment{tabular}{\zihao{\l_@@_misc_tabular_font_size_tl}\linespread{\l_@@_misc_tabular_row_separation_tl}\selectfont}
+  \AtBeginEnvironment{tabular*}{\zihao{\l_@@_misc_tabular_font_size_tl}\linespread{\l_@@_misc_tabular_row_separation_tl}\selectfont}
+  \AtBeginEnvironment{tabularx}{\zihao{\l_@@_misc_tabular_font_size_tl}\linespread{\l_@@_misc_tabular_row_separation_tl}\selectfont}
+  \AtBeginEnvironment{longtable}{\zihao{\l_@@_misc_tabular_font_size_tl}\linespread{\l_@@_misc_tabular_row_separation_tl}\selectfont}
 }
 %    \end{macrocode}
 % \end{macro}
@@ -1632,8 +1635,6 @@
   % 调整浮动体与文字之间的距离
   \addtolength{\intextsep}{\l_@@_misc_float_separation_tl\baselineskip}
   \addtolength{\textfloatsep}{\l_@@_misc_float_separation_tl\baselineskip}
-  % 调整表格各行之间的距离
-  \cs_set:Npn \arraystretch {\l_@@_misc_tabular_row_separation_tl}
 }
 %    \end{macrocode}
 % \end{macro}

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2670,7 +2670,7 @@
 
     \cleardoublepage
     \linespread{1.53}\selectfont
-
+    \setlength{\parskip}{0\baselineskip}
     \@@_if_bachelor_thesis:T {
       \begin{center}
         \vspace*{-17bp}
@@ -2740,7 +2740,7 @@
 \NewDocumentEnvironment {abstractEn} {}
   {
     \linespread{1.53}\selectfont
-
+    \setlength{\parskip}{0\baselineskip}
     \@@_if_bachelor_thesis:T {
       \begin{spacing}{0.95}
         \centering


### PR DESCRIPTION
- 修复摘要段落间距
发现研究生模板摘要第一页段落间距过大的问题，第二页、英文摘要与本科生模板均无此问题，无法定位问题来源。给出一种解决方案。
  - 修改前
  ![image](https://github.com/BITNP/BIThesis/assets/62272084/0eeb4f82-5dc3-490a-9cb2-3ad2613ee748)
  ![image](https://github.com/BITNP/BIThesis/assets/62272084/ca24784b-5d9a-45f7-a518-17c0ba42fa07)
  - 修改后
  ![image](https://github.com/BITNP/BIThesis/assets/62272084/1d582372-22b4-424c-b53b-a8562e8270ce)
- 修复表格行距
使用另一个命令方案解决`tabularRowSeparation`问题 #498 #499 ，顺便添加`longtable`支持 #501 。
  - 效果
  ![image](https://github.com/BITNP/BIThesis/assets/62272084/eedb0f8d-7d27-46af-9999-43802f85b949)
  - 测试代码
```tex
main.tex
\BITSetup{
  misc = {
    tabularRowSeparation = 3,
  },
}

chapter.tex
\begin{equation}
  \begin{bmatrix}
    1 & 0 \\
    1 & 0 \\
    1 & 0 \\
    1 & 0 \\
    1 & 0 \\
    1 & 0 \\
  \end{bmatrix}
\end{equation}

\begin{longtable}{ccccc}
    \caption{Longtable} \\
    \toprule
    项目    & 产量    & 销量    & 产值   & 比重    \\ \midrule
    \endfirsthead
    手机    & 1000  & 10000 & 500  & 50\%  \\
    计算机   & 5500  & 5000  & 220  & 22\%  \\
    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
    合计    & 17600 & 16000 & 1000 & 100\% \\ \bottomrule
\end{longtable}
```