### PR TITLE
feat: 调整算法与文字之间的距离（针对algorithm2e宏包）

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1334,6 +1334,23 @@ floatSeparation = (*(0)|\marg{实数}*)
 
 \end{function}
 
+\begin{function}[added=2024-05-20]{misc/algorithmSeparation}
+\begin{bitsyntax}[emph={[1]algorithmSeparation}]
+floatSeparation = (*(12pt plus 4pt minus 4pt)|\marg{长度}*)
+\end{bitsyntax}
+
+ \textit{此选项一般不需要用户自行修改。}
+
+ 此选项用于调整算法与正文之间的距离。距离用\href{https://www.overleaf.com/learn/latex/Lengths_in_LaTeX}{长度}表示，例如 |0.5em| 大致是半个字高。默认值更复杂一些，它表示以12点为基准，允许上下浮动4点。
+
+ （学校既无明文规定，也无实例。）
+
+ 此选项目前只支持 |algorithm2e| 宏包的 |algorithm| 环境。
+
+ \textit{请在导言区使用此选项。}
+
+\end{function}
+
 \begin{function}[added=2024-04-30, updated=2024-05-13]{misc/tabularRowSeparation}
 \begin{bitsyntax}[emph={[1]tabularRowSeparation}]
 tabularRowSeparation = (*(1)|\marg{正实数}*)

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -736,6 +736,8 @@
     % 浮动体相关的各种间距
     floatSeparation .tl_set:N = \l_@@_misc_float_separation_tl,
     floatSeparation .initial:n = {0},
+    algorithmSeparation .tl_set:N = \l_@@_misc_algorithm_separation_tl,
+    algorithmSeparation .initial:n = {12pt plus 4pt minus 4pt},
     tabularRowSeparation .tl_set:N = \l_@@_misc_tabular_row_separation_tl,
     tabularRowSeparation .initial:n = {1},
   }
@@ -1648,6 +1650,12 @@
   % 调整浮动体与文字之间的距离
   \addtolength{\intextsep}{\l_@@_misc_float_separation_tl\baselineskip}
   \addtolength{\textfloatsep}{\l_@@_misc_float_separation_tl\baselineskip}
+  % 调整算法与文字之间的距离
+  % 针对 algorithm2e 宏包
+  \@ifpackageloaded{algorithm2e}{
+    % 宏包手册介绍可自定义宏，再`\SetAlgoSkip`；我们为简洁，直接覆写。
+    \renewcommand{\@algoskip}{\vspace{\l_@@_misc_algorithm_separation_tl}}
+  }{}
 }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
针对algorithm2e宏包，添加`misc/algorithmSeparation`选项，可供调整算法与文字之间的距离。

与之前版本相比，默认间距会从约3点增大到约12点。

Fixes #494

## 默认值的依据

algorithm2e宏包原本的默认值相当于`\smallskip`，此PR的默认值相当于`\bigskip`。

根据`texdoc source2e`，在 LaTeX 中，这些 skip 用`\vspace`实现。

```latex
\def\smallskip{\vspace\smallskipamount}
\def\bigskip{\vspace\bigskipamount}

\newskip\smallskipamount \smallskipamount=3pt plus 1pt minus 1pt
\newskip\bigskipamount \bigskipamount =12pt plus 4pt minus 4pt
```

其中`12pt plus 4pt minus 4pt`表示以`12pt`为基准，允许上下浮动`4pt`。

## MWE

旧版：
![图片](https://github.com/BITNP/BIThesis/assets/73375426/361534e5-6108-4e19-8729-da8597df1770)

默认：
![图片](https://github.com/BITNP/BIThesis/assets/73375426/2a8be46f-1a39-4020-8589-4cec40e3a8b2)

设为`5em`：
![图片](https://github.com/BITNP/BIThesis/assets/73375426/cd33630a-8451-4a17-a700-b7056d6d8bd2)

```latex
\documentclass[type=bachelor]{bithesis}

\BITSetup{
  misc = {
    algorithmSeparation = {5em},
  },
}

\usepackage[ruled, algochapter]{algorithm2e}

\begin{document}

在这里添加第二章、第三章……TeX 文件的引用
在这里添加第二章、第三章……TeX 文件的引用
在这里添加第二章、第三章……TeX 文件的引用
在这里添加第二章、第三章……TeX 文件的引用
在这里添加第二章、第三章……TeX 文件的引用
在这里添加第二章、第三章……TeX 文件的引用
在这里添加第二章、第三章……TeX 文件的引用

\begin{algorithm}[H]
\SetAlgoLined
\KwData{this text}
\KwResult{how to write algorithm with \LaTeX2e }
initialization\;
\While{not at end of this document}{
read current\;
\eIf{understand}{
go to next section\;
current section becomes this one\;
}{
}}go back to the beginning of current section\;
\caption{How to write algorithms}
\end{algorithm}

在这里添加第二章、第三章……TeX 文件的引用
在这里添加第二章、第三章……TeX 文件的引用
在这里添加第二章、第三章……TeX 文件的引用
在这里添加第二章、第三章……TeX 文件的引用

\end{document}
```