### PR TITLE
refactor: 让硕博模板书脊上下居中，并适应长标题，避免与姓名粘连

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1916,24 +1916,23 @@
   \cleardoublepage
   \currentpdfbookmark{书脊}{frontmatter:paperback}
   \begin{titlepage}
-   \vskip 5cm
-   \begin{center}
+    \centering
+    % 实现竖排——将水平宽度设得很窄，让文字自动换行，并改小行距
     \linespread{1.1}\selectfont
-    \begin{minipage}[t][19.7cm]{2em}
-      \begin{center}
-        {
-          \heiti\zihao{3}
-          \tl_if_blank:VTF \l_@@_value_vertical_title_tl 
-            {\l_@@_value_title_tl}{\l_@@_value_vertical_title_tl}
-        }
-          \vfill
-        {\heiti\zihao{3}\@@_secret_info:nn{\l_@@_value_author_tl}{\g_@@_const_substitute_symbol_tl\quad\g_@@_const_substitute_symbol_tl\quad\g_@@_const_substitute_symbol_tl}}
-          \vfill
-        {\heiti\zihao{3}\c_@@_label_university_tl}
-      \end{center}
+    \begin{minipage}[c][19.7cm]{2em}
+      \centering
+      {
+        \heiti\zihao{3}
+        \tl_if_blank:VTF \l_@@_value_vertical_title_tl 
+          {\l_@@_value_title_tl}{\l_@@_value_vertical_title_tl}
+      }
+      \par
+      \vspace{1em plus 1fill}
+      {\heiti\zihao{3}\@@_secret_info:nn{\l_@@_value_author_tl}{\g_@@_const_substitute_symbol_tl\quad\g_@@_const_substitute_symbol_tl\quad\g_@@_const_substitute_symbol_tl}}
+      \par
+      \vspace{1em plus 1fill}
+      {\heiti\zihao{3}\c_@@_label_university_tl}
     \end{minipage}
-   \end{center}
-   % \vskip 5cm
   \end{titlepage}
 }
 %    \end{macrocode}
@@ -2612,9 +2611,20 @@
 %    \begin{macrocode}
 \NewDocumentCommand \MakePaperBack {}
   {
+    % 上下各留出规定的边距，到下一页再恢复。
+    % 若标题超长，自然会向上下溢出。
+    %
+    % 必须在顶层操作，不然影响不确定。
+    % https://tex.stackexchange.com/q/718581
+    %
+    % 单纯`\newgeometry`再`\restoregeometry`相当于仅仅`\clearpage`，也无问题。
+    \newgeometry{
+      vmargin = 5cm,
+    }
     \begin{blindPeerReview}[\l_@@_cover_hide_cover_in_peer_review_bool]
       \make_paper_back:
     \end{blindPeerReview}
+    \restoregeometry
   }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
Resolves #505

<!--
TODO：现在干扰了下一页的`\stretch`。
-->

## MWE

```latex
% !TeX program = xelatex
% !BIB program = biber

\documentclass[type=master]{bithesis}

\BITSetup{
  info = {
    author = {杜甫},
    % title = 八月秋高风怒号卷我屋上三重茅茅飞渡江洒江郊高者挂罥长林梢下者飘转沉塘坳,
    title = 形状记忆聚氨酯的合成及其在织物中的应用,
    % verticalTitle = {形状记忆聚氨酯{L } {T } {X }的合成 \rotatebox[origin=c]{-90}{Feng Kaiyu} 及其在织物中的应用},
  },
}

\begin{document}
  \MakePaperBack
\end{document}
```

- `old.pdf`：旧版
- `new.pdf`：此PR
- 其它PDF：Word模板

### 标准例子

![图片](https://github.com/BITNP/BIThesis/assets/73375426/ca7d8312-3144-4165-9373-a0ce8d589bbe)
![图片](https://github.com/BITNP/BIThesis/assets/73375426/390c4d89-d813-444c-b18e-2cfc8f79d800)
![图片](https://github.com/BITNP/BIThesis/assets/73375426/90ee8197-ae32-413c-9221-6ba922ba6edd)

### 特殊例子

![图片](https://github.com/BITNP/BIThesis/assets/73375426/ff7c31d2-2c10-487e-a4f4-787cc7e4b7b5)
![图片](https://github.com/BITNP/BIThesis/assets/73375426/bf1a49cd-46b1-45b8-922f-93bd459789d2)

### 测量

29.7 mm / 941 × 158 = 5.0 mm.

![图片](https://github.com/BITNP/BIThesis/assets/73375426/9b26aaba-4fd4-4fff-b355-d32a8ffdcacf)
![图片](https://github.com/BITNP/BIThesis/assets/73375426/4a59f75c-7474-4aae-8e06-25fb097be163)
![图片](https://github.com/BITNP/BIThesis/assets/73375426/4dff1ba5-33ce-4377-9576-9af551cb4895)


## 具体修改

- `\vskip` → `\newgeometry` + `\restoregeometry`

  原来的`\vskip`没生效（删掉后编译结果相同），而且需要从上边距开始算。干脆改边距好了。

- `center`环境 → `\centering`

  lshort-zh-cn：`center`等环境会在上下文产生一个额外间距，而`\centering`等命令不产生，只是改变对齐方式。

- `minipage`环境的对齐方式 `t` → `c`

  这样遇到超长标题时，可以向两边溢出。

- `\vfill` → `\par` + `\vpace`

  `\vspace`可以设置间距最小值，避免标题稍长就和姓名学校粘在一起。

  另外，`\vfill`会直接生效，而`\vspace`不会，所以要加`\par`。