### PR TITLE
feat: 适配`longtable`宏包

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1351,7 +1351,7 @@ floatSeparation = (*(12pt plus 4pt minus 4pt)|\marg{长度}*)
 
 \end{function}
 
-\begin{function}[added=2024-04-30, updated=2024-05-13]{misc/tabularRowSeparation}
+\begin{function}[added=2024-04-30, updated=2024-05-25]{misc/tabularRowSeparation}
 \begin{bitsyntax}[emph={[1]tabularRowSeparation}]
 tabularRowSeparation = (*(1)|\marg{正实数}*)
 \end{bitsyntax}
@@ -1362,7 +1362,7 @@ tabularRowSeparation = (*(1)|\marg{正实数}*)
 
   学校没有明文规定，不过设为1.25更接近本科Word模板实作，设为1.6更接近硕博Word模板实作。
 
-  此选项影响的“表格”具体包括标准 |tabular|、|tabular*| 环境，以及 |tabularx| 宏包提供的环境。并不影响 |longtable| 宏包提供的环境，因为宏包已经调节了。
+  此选项影响的“表格”具体包括标准 |tabular|、|tabular*| 环境，以及 |tabularx| 和 |longtable| 宏包提供的环境。
 
   \textit{请在导言区使用此选项。}
 

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1580,6 +1580,9 @@
     % 至于表格，虽然其caption位置在上方（而图片是在下方），
     % 但 `caption` 宏包已考虑这种区别，统一设置 `belowskip` 即可。
     \captionsetup{belowskip=-5pt}
+    % 不过 longtable 宏包提供的环境比较奇怪，不设置 belowskip 时间距已较小，
+    % 设置成负数还导致 caption 和表格本体的距离变大。因此我们撤销更改。
+    \captionsetup[longtable]{belowskip=0pt}
 
     % 此外在浮动体内部，调整表格 caption 和表格本体间的距离。
     % 本来默认有一定空隙，现改为紧贴，这样更接近Word模板实作。

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1028,6 +1028,13 @@
   \setlength{\intextsep}{1.80\baselineskip plus 0.2\baselineskip minus 0.2\baselineskip}
   % 浮动体位于页面顶部或底部时，调整浮动体与正文之间的距离，后或前加上一行空白
   \setlength{\textfloatsep}{1.80\baselineskip plus 0.2\baselineskip minus 0.2\baselineskip}
+  \AtBeginDocument {
+    % longtable 宏包有另外的机制，需专门调整
+    \@ifpackageloaded{longtable}{
+      \setlength{\LTpre}{0.60\baselineskip plus 0.2\baselineskip minus 0.2\baselineskip}
+      \setlength{\LTpost}{1.60\baselineskip plus 0.2\baselineskip minus 0.2\baselineskip}
+    }{}
+  }
 }
 %    \end{macrocode}
 %
@@ -1580,7 +1587,7 @@
     % 至于表格，虽然其caption位置在上方（而图片是在下方），
     % 但 `caption` 宏包已考虑这种区别，统一设置 `belowskip` 即可。
     \captionsetup{belowskip=-5pt}
-    % 不过 longtable 宏包提供的环境比较奇怪，不设置 belowskip 时间距已较小，
+    % 不过 longtable 宏包有另外的机制，不设置 belowskip 时间距已可较小，
     % 设置成负数还导致 caption 和表格本体的距离变大。因此我们撤销更改。
     \captionsetup[longtable]{belowskip=0pt}
 
@@ -1654,6 +1661,11 @@
   % 调整浮动体与文字之间的距离
   \addtolength{\intextsep}{\l_@@_misc_float_separation_tl\baselineskip}
   \addtolength{\textfloatsep}{\l_@@_misc_float_separation_tl\baselineskip}
+  % longtable 宏包有另外的机制，需专门调整
+  \@ifpackageloaded{longtable}{
+    \addtolength{\LTpre}{\l_@@_misc_float_separation_tl\baselineskip}
+    \addtolength{\LTpost}{\l_@@_misc_float_separation_tl\baselineskip}
+  }{}
   % 调整算法与文字之间的距离
   % 针对 algorithm2e 宏包
   \@ifpackageloaded{algorithm2e}{

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1495,6 +1495,10 @@
   % preamble 中也不会有影响。
   %
   % 支持标准tabular、tabular*环境和宏包tabularx、longtable。
+  %
+  % 为保证各种表格效果一致，要先手动重置setspace宏包漏掉的longtable；
+  \AtBeginEnvironment {longtable} {\singlespacing}
+  % 之后再统一设置。
   \clist_map_inline:nn 
     {tabular, tabular*, tabularx, longtable}
     {
@@ -1504,10 +1508,7 @@
         % 而longtable的caption虽在环境内，但caption宏包能正常处理。
         \zihao{\l_@@_misc_tabular_font_size_tl}
         % 各行间距只想影响表格，不想影响矩阵，因此也必须在钩子中设置。
-        % 另外，longtable宏包已经调节了空隙，我们就不重复调节了。
-        \str_if_eq:nnF {##1} {longtable} {
-          \cs_set:Npn \arraystretch {\l_@@_misc_tabular_row_separation_tl}
-        }
+        \cs_set:Npn \arraystretch {\l_@@_misc_tabular_row_separation_tl}
       }
     }
 }


### PR DESCRIPTION
继续 #499 和 #504。

- [x] 支持用`misc/tabularRowSeparation`调节`longtable`宏包

  https://github.com/BITNP/BIThesis/issues/501#issuecomment-2130053861

- [x] 去除longtable表格上框线和caption的多余间距。

  https://github.com/BITNP/BIThesis/issues/501#issuecomment-2132080016

- [x] 让longtable与文字的间距与其它浮动体相近，并支持用`misc/floatSeparation`统一调整

  它似乎不受`\textfloatsep`等控制。

## 对比

### 旧（左）新（右）对比：

![图片](https://github.com/BITNP/BIThesis/assets/73375426/c613b8ba-4671-4e59-be3b-c497096ac9ff)

### 新版

![图片](https://github.com/BITNP/BIThesis/assets/73375426/47a93d9b-411e-4c61-9ff5-d1d2b195d7b0)
![图片](https://github.com/BITNP/BIThesis/assets/73375426/cb8b4adf-4355-47e7-a235-f48b326c9792)

### 新版 + `\BITSetup`

```latex
\BITSetup{
  misc/floatSeparation = -1.5, % 仅测试，随意指定的
  misc/tabularRowSeparation = 1.25, % 本科表格行高
}
```

![图片](https://github.com/BITNP/BIThesis/assets/73375426/2f248d8a-530f-49e8-aee3-b1c9549a4faf)
![图片](https://github.com/BITNP/BIThesis/assets/73375426/b6ddb60e-95db-4e6d-9c2c-df319dcc7f25)


设置

### 测试用例

```latex
% !TeX program = xelatex
% !BIB program = biber

\documentclass[type=bachelor]{bithesis}
% \BITSetup{
%   misc/floatSeparation = -1.5,
%   misc/tabularRowSeparation = 1.25,
% }

\usepackage{tabularx}
\usepackage{longtable}

\usepackage{zhlipsum}

\begin{document}

\frontmatter
\mainmatter

\zhlipsum[1][name=zhufu]

\begin{table}[ht]
  \centering
  \caption{Tabular Lg} % 都含“Lg”两个伸长的字母，控制变量
  \begin{tabular}{*{5}{>{\centering\arraybackslash}p{5em}}}
    \toprule
    项目    & 产量    & 销量    & 产值   & 比重    \\ \midrule
    手机    & 1000  & 10000 & 500  & 50\%  \\
    计算机   & 5500  & 5000  & 220  & 22\%  \\
    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
    合计    & 17600 & 16000 & 1000 & 100\% \\ \bottomrule
  \end{tabular}
\end{table}

\zhlipsum[2-3][name=zhufu]

\begin{table}[ht]
  \centering
  \caption{Tabular* Lg}
  \begin{tabular*}{32em}{@{\extracolsep{\fill}}ccccc}
    \toprule
    项目    & 产量    & 销量    & 产值   & 比重    \\ \midrule
    手机    & 1000  & 10000 & 500  & 50\%  \\
    计算机   & 5500  & 5000  & 220  & 22\%  \\
    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
    合计    & 17600 & 16000 & 1000 & 100\% \\ \bottomrule
  \end{tabular*}
\end{table}

\zhlipsum[4-6][name=zhufu]

\begin{table}[ht]
  \centering
  \caption{Tabularx Lg}
  \begin{tabularx}{32em}{*{5}{>{\centering\arraybackslash}X}}
    \toprule
    项目    & 产量    & 销量    & 产值   & 比重    \\ \midrule
    手机    & 1000  & 10000 & 500  & 50\%  \\
    计算机   & 5500  & 5000  & 220  & 22\%  \\
    笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
    合计    & 17600 & 16000 & 1000 & 100\% \\ \bottomrule
  \end{tabularx}
\end{table}

\zhlipsum[7-9][name=zhufu]

\begin{longtable}[ht]{ccccc}
  \caption{Long table Lg}                 \\
  \toprule
  项目    & 产量    & 销量    & 产值   & 比重    \\
  \midrule
  \endfirsthead
  \multicolumn{5}{l}{续表}               \\
  \toprule
  项目    & 产量    & 销量    & 产值   & 比重    \\
  \midrule
  \endhead
  \midrule
  \multicolumn{5}{r}{{续下页}}            \\
  \endfoot
  \bottomrule
  \endlastfoot
  手机    & 1000  & 10000 & 500  & 50\%  \\
  计算机   & 5500  & 5000  & 220  & 22\%  \\
  笔记本电脑 & 1100  & 1000  & 280  & 28\%  \\ \midrule
  合计    & 17600 & 16000 & 1000 & 100\% \\
\end{longtable}

\zhlipsum[10-13][name=zhufu]

\end{document}
```
