### PR TITLE
fix: remove redundant `\currentpdfbookmark` for English bachelor thesis

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2693,14 +2693,15 @@
         \vspace{-8pt}
       }
 
-      % 添加目录书签
-      \currentpdfbookmark{\c__bithesis_label_toc_tl}{ch:toc}
       % 制作目录
       \tableofcontents
 
       % 在本科生全英文模板中，添加「目录」本身到目录中。
-      \@@_if_thesis_int_type:nT {3} {
-        \addcontentsline{toc}{chapter}{\c_@@_label_toc_en_tl}
+      \__bithesis_if_thesis_int_type:nTF {3} {
+        \addcontentsline{toc}{chapter}{\c__bithesis_label_toc_en_tl}
+      } {
+        % 添加目录书签
+        \currentpdfbookmark{\c__bithesis_label_toc_tl}{ch:toc}
       }
 
       % 单独成页

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -216,6 +216,7 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_if_thesis_int_type:nTF #1#2#3 {\int_compare:nNnTF {\g_@@_thesis_type_int} = {#1} {#2} {#3}}
 \cs_new:Npn \@@_if_thesis_int_type:nT #1#2 {\@@_if_thesis_int_type:nTF {#1} {#2} {}}
+\cs_new:Npn \__bithesis_if_thesis_int_type:nF #1#2 {\__bithesis_if_thesis_int_type:nTF {#1} {} {#2}}
 %    \end{macrocode}
 % \end{macro}
 
@@ -2693,15 +2694,17 @@
         \vspace{-8pt}
       }
 
+      % 添加目录书签
+      \__bithesis_if_thesis_int_type:nF {3} {
+        \currentpdfbookmark{\c__bithesis_label_toc_tl}{ch:toc}
+      }
+
       % 制作目录
       \tableofcontents
 
       % 在本科生全英文模板中，添加「目录」本身到目录中。
-      \__bithesis_if_thesis_int_type:nTF {3} {
+      \__bithesis_if_thesis_int_type:nT {3} {
         \addcontentsline{toc}{chapter}{\c__bithesis_label_toc_en_tl}
-      } {
-        % 添加目录书签
-        \currentpdfbookmark{\c__bithesis_label_toc_tl}{ch:toc}
       }
 
       % 单独成页

--- a/templates/undergraduate-thesis-en/main.tex
+++ b/templates/undergraduate-thesis-en/main.tex
@@ -44,9 +44,10 @@
     % 想要删除某项封面信息，直接删除该项即可。
     % 想要让某项封面信息留空（但是保留下划线），请传入空白符组成的字符串，如"{~}"。
     % 如需要换行，则用 “\\” 符号分割。
+    title = 你的论文标题（中文）,
     titleEn = Your Thesis Title,
     school = School of Mechanical Engineering,
-    major = Bechelor of Science in Mechanical Engineering,
+    major = Bachelor of Science in Mechanical Engineering,
     author = Feng Kaiyu,
     studentId = 11xxxxxxxx,
     supervisor = Alex Zhang,


### PR DESCRIPTION
* 在本科全英文模板编译出的PDF书签中，会同时出现"目录"和"Table of Content"，似乎是 #480 引入的Bug。
![image](https://github.com/BITNP/BIThesis/assets/28673129/ecc4178a-ea5e-4635-8f4a-b6e09159b0e9)

* 在全英文模板`main.tex`中添加了title属性，以此在中文摘要中输出正确标题。修复了样例中的"Bachelor"拼写错误。