### PR TITLE
盲评相关文档、自动设置`hideCoverInPeerReview`

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -694,17 +694,27 @@ underlineOffset = (*(-10pt)|\marg{任意长度}*)
   设置封面信息中下划线的偏移量。
 \end{function}
 
-\begin{function}[added=2023-05-09]{cover/hideCoverInPeerReview}
+\begin{function}[added=2023-05-09, updated=2024-06-14]{cover/hideCoverInPeerReview}
 \begin{bitsyntax}[emph={[1]hideCoverInPeerReview}]
-hideCoverInPeerReview = (*(false)|true*)
+hideCoverInPeerReview = (*(from-thesis-type)|false|true*)
 \end{bitsyntax}
 
-  在盲审模式下，不渲染封面。
+  \textit{此选项默认值会按论文类型自动设置，一般已满足要求，不需要用户自行修改。}
+
+  在盲审模式下，是否不渲染封面。
+
+  \begin{itemize}
+    \item 若设为 |true|，盲审模式下直接删除封面。
+    \item 若设为 |false|，盲审模式下保留封面，只是隐去个人信息。
+    \item （默认）若设为 |from-thesis-type|，自动根据论文类型设置。具体来说，本科生设为 |true|，研究生设为 |false|。
+  \end{itemize}
+
+  未启用盲审模式时，此选项无效果。
 \end{function}
 
 \begin{function}[added=2024-03-22]{cover/showSpecialTypeBox}
 \begin{bitsyntax}[emph={[1]showSpecialTypeBox}]
-hideCoverInPeerReview = (*(false)|true*)
+showSpecialTypeBox = (*(false)|true*)
 \end{bitsyntax}
 
   展示「特殊类型」（研究生模板）的那个信息框。

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -613,8 +613,17 @@
     underlineThickness .initial:n = {1pt},
     underlineOffset .dim_set:N = \l_@@_cover_underline_offset_dim,
     underlineOffset .initial:n = { -10pt },
-    hideCoverInPeerReview .bool_set:N = \l_@@_cover_hide_cover_in_peer_review_bool,
-    hideCoverInPeerReview .initial:n = {false},
+    hideCoverInPeerReview .choice:,
+    hideCoverInPeerReview / true .code:n = { \bool_set_true:N \l_@@_cover_hide_cover_in_peer_review_bool },
+    hideCoverInPeerReview / false .code:n = { \bool_set_false:N \l_@@_cover_hide_cover_in_peer_review_bool },
+    hideCoverInPeerReview / from-thesis-type .code:n = {
+      \@@_if_graduate:TF {
+        \bool_set_false:N \l_@@_cover_hide_cover_in_peer_review_bool
+      } {
+        \bool_set_true:N \l_@@_cover_hide_cover_in_peer_review_bool
+      }
+    },
+    hideCoverInPeerReview .initial:n = {from-thesis-type},
     % 研究生的「特殊类型」
     showSpecialTypeBox .bool_set:N = \l_@@_cover_show_special_type_box_bool,
     showSpecialTypeBox .initial:n = {false}

--- a/templates/undergraduate-thesis-en/main.tex
+++ b/templates/undergraduate-thesis-en/main.tex
@@ -35,8 +35,6 @@
     headerImage = images/header.png,
     % 封面标题需要“华文细黑”，如无必要请勿修改该项。
     xiheiFont = STXIHEI.TTF,
-    % 本科生盲审要求删去封面，而不是隐藏封面信息。
-    hideCoverInPeerReview = true,
     % 修改封面日期
     % date = May 31 2023,
   },

--- a/templates/undergraduate-thesis/main.tex
+++ b/templates/undergraduate-thesis/main.tex
@@ -36,8 +36,6 @@
     xiheiFont = STXIHEI.TTF,
     %% 使用以下参数来自定义封面日期
     % date = 2022年6月,
-    % 本科生盲审要求删去封面，而不是隐藏封面信息。
-    hideCoverInPeerReview = true,
   },
   info = {
     % 想要删除某项封面信息，直接删除该项即可。

--- a/the-graduates-handbook/chapters/ch2-example-bachelor-blind.tex
+++ b/the-graduates-handbook/chapters/ch2-example-bachelor-blind.tex
@@ -1,0 +1,2 @@
+\documentclass[type=bachelor, blindPeerReview=true]{bithesis}
+% 或 \documentclass[type=bachelor_english, blindPeerReview=true]{bithesis}

--- a/the-graduates-handbook/chapters/ch2-example-master-blind.tex
+++ b/the-graduates-handbook/chapters/ch2-example-master-blind.tex
@@ -1,0 +1,1 @@
+\documentclass[type=master, blindPeerReview=true]{bithesis}

--- a/the-graduates-handbook/chapters/ch2-template-usage.tex
+++ b/the-graduates-handbook/chapters/ch2-template-usage.tex
@@ -223,4 +223,15 @@
   \item 在正文中使用 \verb|\cite{key}| 或 \verb|\parencite{key}| 等命令引用文献。
 \end{enumerate}
 
+\section{生成盲审版论文}
 
+提交论文用于匿名评阅（又名盲审或盲评）时，需要“隐去论文作者和导师姓名，以及致谢、论文成果等与作者有关的信息”。
+% 以上引文源于《北京理工大学关于本科毕业设计（论文）评阅的规定（试行）》（2023年4月修订）。
+
+此时请编辑 \texttt{main.tex}，给开头 \verb|\documentclass| 加上 \verb|blindPeerReview=true| 选项。
+修改后如下：
+\isGraduateTF{
+  \lstinputlisting[language=TeX]{chapters/ch2-example-master-blind.tex}
+}{
+  \lstinputlisting[language=TeX]{chapters/ch2-example-bachelor-blind.tex}
+}


### PR DESCRIPTION
Resolves #533

<!--
> [!WARNING]
> 此 PR 目前还只是为了讨论，请勿合并。如果没问题，改了快速使用指南再合并。
-->

![图片](https://github.com/BITNP/BIThesis/assets/73375426/e241b911-b844-4dbb-adb7-388041b30524)

![图片](https://github.com/BITNP/BIThesis/assets/73375426/d2d65f64-31c0-42c1-ba51-24496c35037a)

<details>
<summary>其它方案</summary>

![图片](https://github.com/BITNP/BIThesis/assets/73375426/13beb6d8-026d-458a-b8f5-1ada10fbcb06)

更新文档时发现模板已经有别的地方在`.initial`实现了“自动按论文类型设置初始值”：

https://github.com/BITNP/BIThesis/blob/cad285745fb2482f0f41d4d6b8814ae59a3f7359/bithesis.dtx#L819-L824

https://github.com/BITNP/BIThesis/blob/cad285745fb2482f0f41d4d6b8814ae59a3f7359/bithesis.dtx#L526-L535

要改成这样吗？

</details>