### PR TITLE
feat: 改小数学行距至西文水平

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1847,8 +1847,15 @@ addTOC = (*<(true)|false>*)
 
 \textit{请事先安装 XITS 字体。}
 
+此外，如果使用 \TeX{} Gyre Pagella Math 等字面较大的字体，略微增加数学行距可能更美观：
+\begin{latex}
+\setmathfont{texgyrepagella-math.otf}
+\SetMathEnvironmentSinglespace{1.05}
+\end{latex}
+
 \textit{更多字体与使用方法请参考 
-\href{https://ctan.org/pkg/unicode-math?lang=zh}{unicode-math 手册}。}
+\href{https://ctan.org/pkg/unicode-math?lang=zh}{unicode-math 手册}和
+\href{https://ctan.org/pkg/zhlineskip}{zhlineskip 手册}。}
 
 \subsection{如何采用与 Word 相同的中文字体？} \label{sec:word-fonts}
 

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -961,6 +961,9 @@
 \RequirePackage{geometry}
 \RequirePackage[table,xcdraw]{xcolor}
 \RequirePackage{xeCJK}
+% 恢复数学行距（restoremathleading），同时避免改变正文行距。
+% （ctex 默认 linespread 1.3 × LaTeX 默认倍数 1.2 = 1.56）
+\RequirePackage[bodytextleadingratio=1.56]{zhlineskip}
 \RequirePackage{titletoc}
 \RequirePackage{graphicx}
 \RequirePackage{fancyhdr}


### PR DESCRIPTION
Resolves #500

如需恢复数学行距至原先的中文水平，可在导言区将倍数从1调大至1.53：

```latex
\SetMathEnvironmentSinglespace{1.53}
```

## 效果

如下图，减小了数学公式中矩阵的行距，不改变正文行距和段落间距。

![图片](https://github.com/BITNP/BIThesis/assets/73375426/b9a15b8b-4f86-4b8b-83b8-ae04de0d361c)

```latex
\chapter{MWE}

中华民国十五年三月二十五日，就是国立北京女子师范大学为十八日在段祺瑞执政府前遇害的刘和珍杨德群两君开追悼会的那一天，我独在礼
堂外徘徊，遇见程君，前来问我道，“先生可曾为刘和珍写了一点什么没有？”我说“没有”。她就正告我，“先生还是写一点罢；刘和珍生前就
很爱看先生的文章。”

这是我知道的，凡我所编辑的期刊，大概是因为往往有始无终之故罢，销行一向就甚为寥落，然而在这样的生活艰难中，毅然预定了《莽原》
全年的就有她。我也早觉得有写一点东西的必要了，这虽然于死者毫不相干，但在生者，却大抵只能如此而已。倘使我能够相信真有所谓“在
天之灵”，那自然可以得到更大的安慰，——但是，现在，却只能如此而已。

她的姓名第一次为我所见，是在去年夏初杨荫榆女士做女子师范大学校长，开除校中六个学生自治会职员的时候。其中的一个就是她；但是我
不认识。直到后来，也许已经是刘百昭率领男女武将，强拖出校之后了，才有人指着一个学生告诉我，说：这就是刘和珍。其时我才能将姓名
和实体联合起来，心中却暗自诧异。我平素想，能够不为势利所屈，反抗一广有羽翼的校长的学生，无论如何，总该是有些桀骜锋利的，但她
却常常微笑着，态度很温和。
\begin{equation}
\begin{bmatrix}
  1 & 2 & Af \\
    3 & 4 & fA \\
\end{bmatrix}
\end{equation}
待到偏安于宗帽胡同，赁屋授课之后，她才始来听我的讲义，于是见面的回数就较多了，也还是始终微笑着，态度很温和。待到学校恢复旧观
，往日的教职员以为责任已尽，准备陆续引退的时候，我才见她虑及母校前途，黯然至于泣下。此后似乎就不相见。总之，在我的记忆上，那
一次就是永别了。
```

TeX Gyre Pagella Math 示例：
![图片](https://github.com/BITNP/BIThesis/assets/73375426/f46fe643-5372-4742-b334-3013f712c331)

## 副作用

### 加大了 undergraduate-thesis-en 封面各种行距

原因我不太清楚，可能是因为 zhlineskip 补上了某个`\selectfont`。

不过这样更接近中文间距，也更美观。

![图片](https://github.com/BITNP/BIThesis/assets/73375426/23ad64c9-c3fa-4787-ba70-87dca317ec24)

### 略微移动了脚注线

原因我也不清楚，可能是浮点数运算误差。

![图片](https://github.com/BITNP/BIThesis/assets/73375426/20ad00a5-bf4f-4b99-bf4d-91fec7501ed0)
