### PR TITLE
更新本科英文模板以及相关内容

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1442,11 +1442,21 @@ substituteSymbol = (*(*)|\marg{字符串}*),
 \begin{bitsyntax}[emph={[1]degree,major}]
   info = {
     degree = (*(申请学位级别)|\marg{字符串}*),
-    major = (*(学科专业)|\marg{字符串}*),
+    major = (*专业 | 学科专业 | Degree | \marg{字符串}*),
   },
 \end{bitsyntax}
 
-  用于定义封面中个人信息条目的各个常量值。
+  用于定义封面中个人信息条目的各个常量值。默认按论文类型自动设置。
+\end{variable}
+
+\begin{variable}[added=2024-07-09]{const/heading/acknowledgements}
+\begin{bitsyntax}[emph={[1]acknowledgements}]
+  info = {
+    acknowledgements = (*致谢 | Acknowledgements | \marg{字符串}*),
+  },
+\end{bitsyntax}
+
+  用于定义一些固定章节的标题。默认按论文类型自动设置。
 \end{variable}
 
 \section{正文编写}

--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1140,18 +1140,22 @@ chapterLevel = (*<(false)|true>*)
 
 \begin{function}{appendices/title}
 \begin{bitsyntax}[emph={[1]title}]
-title = (*(附录)|\meta{字符串}*)
+title = (*\meta{字符串}*)
 \end{bitsyntax}
 
- 可以覆盖附录的标题名称，默认为「附录」。
+  附录部分的总标题。默认会按论文类型自动设置为「附录」、「附\quad{}录」或“Appendices”。
+
+  仅在 |appendices/chapterLevel| 为 |false| 时有效。
 \end{function}
 
 \begin{function}{appendices/TOCTitle}
 \begin{bitsyntax}[emph={[1]TOCTitle}]
-TOCTitle = (*(附录)|\meta{字符串}*)
+TOCTitle = (*\meta{字符串}*)
 \end{bitsyntax}
 
- 可以覆盖附录在目录中的名称，默认为「附录」。
+  附录在目录中的名称。默认会按论文类型自动设置为「附录」、「附\quad{}录」或“Appendices”。
+
+  仅在 |appendices/chapterLevel| 为 |false| 时有效。
 \end{function}
 
 \subsubsection{攻读学位期间发表论文与研究成果清单选项}

--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1434,7 +1434,7 @@ substituteSymbol = (*(*)|\marg{字符串}*),
   盲审模式下用于替换个人信息的替换符号。
 \end{variable}
 
-\begin{variable}[added=2023-06-11]{const/info/degree,const/info/major}
+\begin{variable}[added=2023-06-11, updated=2024-07-09]{const/info/degree,const/info/major}
 \begin{bitsyntax}[emph={[1]degree,major}]
   info = {
     degree = (*(申请学位级别)|\marg{字符串}*),

--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -721,6 +721,28 @@ showSpecialTypeBox = (*(false)|true*)
   因为美观原因默认关闭，和研究生院确认过这个信息框重要程度比较低。
 \end{function}
 
+\begin{function}[added=2024-07-11]{cover/prefer-zh}
+\begin{bitsyntax}[emph={[1]prefer-zh}]
+prefer-zh = (*(false)|true*)
+\end{bitsyntax}
+
+  是否强制使用中文封面，只适用于\BIThesisTemplates{UTE}。该模板默认封面是英文，而有些学院要求采用中文。
+
+  注意设置 |prefer-zh = true| 不会影响 |const/info/major| 等选项的默认值，请参考英文模板的 README 搭配使用。
+\end{function}
+
+\begin{function}[added=2024-07-11]{cover/reverse-titles}
+\begin{bitsyntax}[emph={[1]reverse-titles}]
+reverse-titles = (*(false)|true*)
+\end{bitsyntax}
+
+  是否调换中英文标题顺序，只适用于本科中文封面。
+  若为 |false|，中文在上，英文在下；若为 |true|，中文在下，英文在上。
+
+  适用于\BIThesisTemplates{UT}，此外\BIThesisTemplates{UTE}设置了 |cover/prefer-zh = true| 时也适用。
+  不适用于\BIThesisTemplates{PT}和硕士、博士学位论文。
+\end{function}
+
 \subsubsection{论文基本信息}
 
 \begin{function}{info}

--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1095,6 +1095,16 @@ abstract = (*(true)|false*)
   是否在目录中索引摘要。
 \end{function}
 
+\begin{function}[added=2024-07-09]{TOC/TOC}
+\begin{bitsyntax}[emph={[1]TOC}]
+TOC = (*(false)|true*)
+\end{bitsyntax}
+
+  \textit{此选项一般不需要用户自行修改。}
+
+  是否在目录中索引目录本身。
+\end{function}
+
 \begin{function}{TOC/symbols}
 \begin{bitsyntax}[emph={[1]symbols}]
 abstract = (*(true)|false*)

--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1085,6 +1085,16 @@ TOC/(*\meta{key}*) = (*\meta{value}*)
  该选项包含许多子项目，用于调整其他选项。具体内容见下：
 \end{function}
 
+\begin{function}[added=2024-07-09]{TOC/title}
+\begin{bitsyntax}[emph={[1]title}]
+title = (*目录 | Table~of~Contents | \meta{字符串}*)
+\end{bitsyntax}
+
+  目录的标题。默认会按论文类型自动设置为「目录」、「目\quad{}录」或“Table~of~Contents”。
+
+  有的学院要求改为“Contents”，这时请自行修改。
+\end{function}
+
 \begin{function}{TOC/abstract,TOC/abstractEn}
 \begin{bitsyntax}[emph={[1]abstract,abstractEn}]
 abstract = (*(true)|false*)

--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -985,6 +985,27 @@ pageVerticalAlign = (*(top)|scattered*)
 \end{optdesc}
 \end{function}
 
+\begin{function}[added=2024-07-09]{style/non-CJK-font-in-headings}
+\begin{bitsyntax}[emph={[1]non-CJK-font-in-headings}]
+non-CJK-font-in-headings = (*(serif)|sans*)
+\end{bitsyntax}
+
+\textit{对于中文模板，此选项一般不需要用户自行修改。}
+
+设置标题中拉丁字母、数字等非汉字部分的字体。
+大致 |serif| 对应 Times New Roman，|sans| 对应 Arial。
+默认为 |serif|。
+
+“标题”除了包含正文标题，还包含摘要页的论文题目、摘要标题，目录、参考文献、附录的标题等。
+
+学校官方规范中，目前描述较模糊；若从正文、封面类推，应为 Times New Roman。
+2024年学校（本科）教务部老师回答其它问题时提到：“所有毕业设计过程文件及论文涉及到的英文和数字用 Times New Roman。”
+当年实际提交时，用 Times New Roman、Arial 甚至字偶间距不正常的黑体都能通过。
+总之，“这不是重点，美观就行”。
+
+若设为 |sans|，请同时参考 |misc/arialFont| 选项。
+\end{function}
+
 \begin{function}[added=2023-03-29]{style/mathFont}
 \begin{bitsyntax}[emph={[1]mathFont}]
 mathFont = (*(cm)|asana|fira|...|xits|none*)
@@ -1268,7 +1289,7 @@ arialFont = (*\marg{字符串}*)
 
   \textit{此选项一般不需要用户自行修改。}
 
-  本科生毕业设计模板（全英文专业）需要设置 Arial 字体。
+  早期（2022年及以前）\BIThesisTemplates{UTE}需要设置 Arial 字体。
   在 Windows 和 macOS 中，该字体已经安装；在 Linux 中需要用户自行安装（如果你是 WSL 用户，可参照\ref{sec:word-fonts}直接使用 Windows 下的字体）。
 \end{function}
 

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -493,7 +493,7 @@
     {conclusion} {结\label_space: 论} {Conclusions},
     % 附录部分的总标题
     {appendix} {附\label_space: 录} {Appendices},
-    {ack} {致\label_space: 谢} {Acknowledgement},
+    {ack} {致\label_space: 谢} {Acknowledgements},
     {figure} {插\label_space: 图} {Illustrations},
     {table} {表\label_space: 格} {Tables},
     % 附录下各部分编号的前缀
@@ -762,6 +762,7 @@
     autoref .meta:nn = { bithesis / const / autoref } { #1 },
     style .meta:nn = { bithesis / const / style } { #1 },
     info .meta:nn = { bithesis / const / info } { #1 },
+    heading .meta:nn = { bithesis / const / heading } { #1 },
   }
 \keys_define:nn { bithesis / const / autoref }
   {
@@ -812,6 +813,13 @@
       } {
         \@@_get_const:N {major}
       }
+    },
+  }
+\keys_define:nn { bithesis / const / heading }
+  {
+    acknowledgements .tl_set:N = \g_@@_const_heading_acknowledgements_tl,
+    acknowledgements .initial:n = {
+      \@@_get_const:N {ack}
     },
   }
 %    \end{macrocode}
@@ -3032,11 +3040,7 @@
         subsubsection/number = \arabic{section}. \arabic{subsection}. \arabic{subsubsection},
       }
 
-      \@@_if_thesis_english:TF {
-        \chapter{\c_@@_label_ack_en_tl}
-      } {
-        \chapter{\c_@@_label_ack_tl}
-      }
+      \chapter{\g_@@_const_heading_acknowledgements_tl}
       \@@_if_graduate:TF {\fangsong}{}
       #1
     \end{blindPeerReview}

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1489,13 +1489,7 @@
 % 定义前置内容的页面样式。
 %    \begin{macrocode}
 \RenewDocumentCommand \frontmatter {} {
-  \int_compare:nNnTF {\g_@@_thesis_type_int} = {3}
-  {
-    % 本科全英文专业论文，页码使用小罗马数字。
-    \pagenumbering{roman}
-  } {
-    \pagenumbering{Roman}
-  }
+  \pagenumbering{Roman}
   % 这部分的章节标题不进行编号。
   \ctexset{
     chapter = {

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1343,8 +1343,10 @@
 \cs_new:Npn \l_@@_title_font_cs:n #1 {
   \@@_if_thesis_int_type:nTF {3}
   {
-    \arialfamily #1
+    % 尽管是英文模板，但仍可能出现中文，因此需设置中文字体。
+    \heiti\arialfamily #1
   } {
+    % 西文保持原本的 Times New Roman。黑体一般不搭配衬线体，但学校要求如此。
     \heiti #1
   }
 }
@@ -2763,16 +2765,8 @@
     }
 
     \@@_if_bachelor_thesis:T {
-      \@@_if_thesis_int_type:nTF {3}
-      {
-        \ctexset{
-          chapter/titleformat = {\heiti}
-        }
-      }
-      {
-        \ctexset{
-          chapter/titleformat = {\textmd}
-        }
+      \ctexset{
+        chapter/titleformat = {\textmd}
       }
     }
 
@@ -2830,19 +2824,8 @@
     }
 
     \@@_if_bachelor_thesis:TF {
-      \@@_if_thesis_int_type:nTF {3}
-      {
-        \ctexset{
-          chapter = {
-            titleformat = {\heiti\zihao{3}\centering\textbf},
-          }
-        }
-      } {
-        \ctexset{
-          chapter = {
-            titleformat = {\heiti\zihao{-3}\centering\textmd},
-          }
-        }
+      \ctexset{
+        chapter/titleformat = {\zihao{-3}\textmd}
       }
     } {
       \ctexset {

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1341,7 +1341,7 @@
 % 定义标题字体。
 %    \begin{macrocode}
 \cs_new:Npn \l_@@_title_font_cs:n #1 {
-  \int_compare:nNnTF {\g_@@_thesis_type_int} = {3}
+  \@@_if_thesis_int_type:nTF {3}
   {
     \arialfamily #1
   } {
@@ -2763,7 +2763,7 @@
     }
 
     \@@_if_bachelor_thesis:T {
-      \int_compare:nNnTF {\g_@@_thesis_type_int} = {3}
+      \@@_if_thesis_int_type:nTF {3}
       {
         \ctexset{
           chapter/titleformat = {\heiti}
@@ -2833,7 +2833,7 @@
     }
 
     \@@_if_bachelor_thesis:TF {
-      \int_compare:nNnTF {\g_@@_thesis_type_int} = {3}
+      \@@_if_thesis_int_type:nTF {3}
       {
         \ctexset{
           chapter = {

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -491,10 +491,12 @@
     {toc} {目\label_space: 录} {Table~of~Contents},
     {abstract} {摘\label_space: 要} {Abstract},
     {conclusion} {结\label_space: 论} {Conclusions},
+    % 附录部分的总标题
     {appendix} {附\label_space: 录} {Appendices},
     {ack} {致\label_space: 谢} {Acknowledgement},
     {figure} {插\label_space: 图} {Illustrations},
     {table} {表\label_space: 格} {Tables},
+    % 附录下各部分编号的前缀
     {appendix_prefix} {附录} {Appendix},
     {reference} {参考文献} {References},
     {university} {北京理工大学} {Beijing~Institute~of~Technology},
@@ -2954,7 +2956,7 @@
     }
 
     \bool_if:NTF \l_@@_appendices_chapter_level_bool {
-      % 附录章节级别
+      % 使用以「chapter」为顶层的附录格式
 
       % 仅设置 \setcounter{chapter}{0} 时，pdf 目录会索引到正文章节。
       % 因此，需要使用 \appendix 重置计数器，并将附录后面的
@@ -2973,7 +2975,7 @@
         \Alph{chapter}
       }
     } {
-      % 附录节（section）级别
+      % 使用以「section」为顶层的附录格式
 
       % 因为不需要用到 chapter counter, 所以直接加一即可。
       \stepcounter{chapter}

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2713,18 +2713,18 @@
         \vspace{-8pt}
       }
 
-      % 添加目录书签
-      \@@_if_thesis_int_type:nF {3} {
+      \@@_if_thesis_int_type:nTF {3} {
+        % 添加「目录」本身到目录中，同时自动添加书签
+        % 此处必须有`\phantomsection`，不然 hyperref 会把链接指向之前摘要的标题。
+        \phantomsection
+        \addcontentsline{toc}{chapter}{\c_@@_label_toc_en_tl}
+      } {
+        % 手动添加目录书签
         \currentpdfbookmark{\c_@@_label_toc_tl}{ch:toc}
       }
 
       % 制作目录
       \tableofcontents
-
-      % 在本科生全英文模板中，添加「目录」本身到目录中。
-      \@@_if_thesis_int_type:nT {3} {
-        \addcontentsline{toc}{chapter}{\c_@@_label_toc_en_tl}
-      }
 
       % 单独成页
       \clearpage

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -628,7 +628,13 @@
     hideCoverInPeerReview .initial:n = {from-thesis-type},
     % 研究生的「特殊类型」
     showSpecialTypeBox .bool_set:N = \l_@@_cover_show_special_type_box_bool,
-    showSpecialTypeBox .initial:n = {false}
+    showSpecialTypeBox .initial:n = {false},
+    % 本科英文模板也可以使用中文封面
+    prefer-zh .bool_set:N = \l_@@_cover_prefer_zh_bool,
+    prefer-zh .initial:n = {false},
+    % 本科英文模板使用中文封面时可能需要调换中英文标题顺序
+    reverse-titles .bool_set:N = \l_@@_cover_reverse_titles_bool,
+    reverse-titles .initial:n = {false},
   }
 %    \end{macrocode}
 %
@@ -2306,7 +2312,15 @@
     \begin{blindPeerReview}[\l_@@_cover_hide_cover_in_peer_review_bool]
     \group_begin:
 
-    \int_case:nn {\g_@@_thesis_type_int}
+    % 封面使用的 thesis-type 可能与整体不同。
+    \int_new:N \l_@@_thesis_type_int
+    \bool_if:NTF \l_@@_cover_prefer_zh_bool {
+      \int_set:Nn \l_@@_thesis_type_int {1}
+    } {
+      \int_set:Nn \l_@@_thesis_type_int \g_@@_thesis_type_int
+    }
+
+    \int_case:nn {\l_@@_thesis_type_int}
     {
       {1}
       {
@@ -2324,17 +2338,28 @@
 
           \zihao{-0}\textbf{\ziju{0.12}\songti{\l_@@_style_headline_tl}}\par
 
-          \vspace{16mm}
+          \vspace{0.5em plus 1fill}
 
-          \zihao{2}\textbf{\xihei:n \l_@@_value_title_tl}\par
+          \group_begin:
+          % 中文标题
+          \tl_set:Nn \l_tmpa_tl {
+            \linespread{1.46}\selectfont
+            \zihao{2}\textbf{\xihei:n \l_@@_value_title_tl}\par
+          }
+          % 英文标题
+          \tl_set:Nn \l_tmpb_tl {
+            \linespread{1.65}\selectfont
+            \zihao{3}\textbf{\l_@@_value_title_en_tl}\par
+          }
 
-          \vspace{3mm}
+          \bool_if:NTF \l_@@_cover_reverse_titles_bool {
+            \l_tmpb_tl \vspace{3mm} \l_tmpa_tl
+          } {
+            \l_tmpa_tl \vspace{3mm} \l_tmpb_tl
+          }
+          \group_end:
 
-          \begin{spacing}{1.2}
-            \zihao{3}\selectfont{\textbf{\l_@@_value_title_en_tl}}\par
-          \end{spacing}
-
-          \vspace{15mm}
+          \vspace{0em plus 1fill}
 
 
           \begin{spacing}{1.8}
@@ -2372,10 +2397,12 @@
             \end{center}
           \end{spacing}
 
-          \vspace*{\fill}
+          \vspace*{1.5em plus 1.5fill}
           \centering
           \zihao{3}\ziju{0.5}\songti{
             \tl_if_empty:NTF \l_@@_cover_date_tl {
+              % 英文模板中 ctex 不会预设日期格式，但仍要保证中文封面的日期按中文习惯
+              \ctexset{today=small}
               \today
             } {
               \l_@@_cover_date_tl

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -877,6 +877,8 @@
   abstract .initial:n = {true},
   abstractEn .bool_set:N = \l_@@_add_abstract_en_to_toc_bool,
   abstractEn .initial:n = {true},
+  TOC .bool_set:N = \l_@@_add_toc_to_toc_bool,
+  TOC .initial:n = {false},
   symbols .bool_set:N = \l_@@_add_symbols_to_toc_bool,
   symbols .initial:n = {true},
 }
@@ -2713,7 +2715,7 @@
         \vspace{-8pt}
       }
 
-      \@@_if_thesis_int_type:nTF {3} {
+      \bool_if:NTF \l_@@_add_toc_to_toc_bool {
         % 添加「目录」本身到目录中，同时自动添加书签
         % 此处必须有`\phantomsection`，不然 hyperref 会把链接指向之前摘要的标题。
         \phantomsection

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2490,7 +2490,7 @@
 
             \clist_set:Nn \l_@@_input_clist {
               {\c_@@_label_school_en_tl} {\l_@@_value_school_tl},
-              {\c_@@_label_major_en_tl} {\l_@@_value_major_tl},
+              {\g_@@_const_info_major_tl} {\l_@@_value_major_tl},
               {\c_@@_label_author_en_tl} {\l_@@_value_author_tl},
               {\c_@@_label_student_id_en_tl} {\l_@@_value_student_id_tl},
               {\c_@@_label_supervisor_en_tl} {\l_@@_value_supervisor_tl},

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -216,7 +216,7 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_if_thesis_int_type:nTF #1#2#3 {\int_compare:nNnTF {\g_@@_thesis_type_int} = {#1} {#2} {#3}}
 \cs_new:Npn \@@_if_thesis_int_type:nT #1#2 {\@@_if_thesis_int_type:nTF {#1} {#2} {}}
-\cs_new:Npn \__bithesis_if_thesis_int_type:nF #1#2 {\__bithesis_if_thesis_int_type:nTF {#1} {} {#2}}
+\cs_new:Npn \@@_if_thesis_int_type:nF #1#2 {\@@_if_thesis_int_type:nTF {#1} {} {#2}}
 %    \end{macrocode}
 % \end{macro}
 
@@ -1651,13 +1651,13 @@
   % 针对 algorithm 宏包
   \@ifpackagewith{algorithm}{chapter}{
     \cs_gset:Npn \thealgorithm
-    {\thechapter\g__bithesis_label_divide_char_tl\arabic{algorithm}}
+    {\thechapter\g_@@_label_divide_char_tl\arabic{algorithm}}
   }{}
   % 针对 algorithm2e 宏包
   \@ifpackagewith{algorithm2e}{algochapter}{
     % 名字中的“cf”是指其作者 Christophe Fiorio。
     \cs_gset:Npn \thealgocf
-    {\thechapter\g__bithesis_label_divide_char_tl\arabic{algocf}}
+    {\thechapter\g_@@_label_divide_char_tl\arabic{algocf}}
   }{}
 
   % 默认的情况下，保留公式和上下文的一定间距。（会比 Word 稍宽一些）
@@ -1724,8 +1724,8 @@
 %
 % 调整插图目录与表格目录的标题。
 %    \begin{macrocode}
-\cs_set:Npn \listfigurename {\currentpdfbookmark{\c__bithesis_label_figure_tl}{ch:figures}\@@_get_const:N {figure}}
-\cs_set:Npn \listtablename {\currentpdfbookmark{\c__bithesis_label_table_tl}{ch:tables}\@@_get_const:N {table}}
+\cs_set:Npn \listfigurename {\currentpdfbookmark{\c_@@_label_figure_tl}{ch:figures}\@@_get_const:N {figure}}
+\cs_set:Npn \listtablename {\currentpdfbookmark{\c_@@_label_table_tl}{ch:tables}\@@_get_const:N {table}}
 %    \end{macrocode}
 %
 % 预定义用户常用的证明环境。
@@ -2704,16 +2704,16 @@
       }
 
       % 添加目录书签
-      \__bithesis_if_thesis_int_type:nF {3} {
-        \currentpdfbookmark{\c__bithesis_label_toc_tl}{ch:toc}
+      \@@_if_thesis_int_type:nF {3} {
+        \currentpdfbookmark{\c_@@_label_toc_tl}{ch:toc}
       }
 
       % 制作目录
       \tableofcontents
 
       % 在本科生全英文模板中，添加「目录」本身到目录中。
-      \__bithesis_if_thesis_int_type:nT {3} {
-        \addcontentsline{toc}{chapter}{\c__bithesis_label_toc_en_tl}
+      \@@_if_thesis_int_type:nT {3} {
+        \addcontentsline{toc}{chapter}{\c_@@_label_toc_en_tl}
       }
 
       % 单独成页

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2817,11 +2817,8 @@
         \centering
         \vspace*{-2bp}
 
-        \@@_if_thesis_int_type:nTF {3} {
-          \arialfamily\zihao{-2}\textbf
-          \l_@@_value_title_en_tl\\
-        } {
-          \heiti\zihao{3}\textbf
+        \l_@@_title_font_cs:n {
+          \zihao{3}\textbf
           \l_@@_value_title_en_tl\\
         }
       \end{spacing}

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -160,7 +160,7 @@
 %
 % \end{macro}
 %
-% \begin{macro}[added=2023-03-16]{\@@_get_const:}
+% \begin{macro}[added=2023-03-16]{\@@_get_const:N}
 % 获取标题、章节、表格、图形等的常量名称。
 % 会区别英文模式和中文模式。
 %   \begin{macrocode}
@@ -873,6 +873,10 @@
 %    \begin{macrocode}
 \keys_define:nn { bithesis / TOC }
 {
+  title .tl_set:N = \l_@@_toc_title_tl,
+  title .initial:n = {
+    \@@_get_const:N {toc}
+  },
   abstract .bool_set:N = \l_@@_add_abstract_to_toc_bool,
   abstract .initial:n = {true},
   abstractEn .bool_set:N = \l_@@_add_abstract_en_to_toc_bool,
@@ -2700,12 +2704,6 @@
         \renewcommand{\baselinestretch}{1.56}
       }
 
-      \@@_if_thesis_english:TF {
-        \tl_set:Nn \l_@@_toc_title_tl {\c_@@_label_toc_en_tl}
-      } {
-        \tl_set:Nn \l_@@_toc_title_tl {\c_@@_label_toc_tl}
-      }
-
       % 自定义目录样式
       \cs_set:Npn \contentsname {
         \fontsize{16pt}{\baselineskip}
@@ -2722,7 +2720,7 @@
         \addcontentsline{toc}{chapter}{\c_@@_label_toc_en_tl}
       } {
         % 手动添加目录书签
-        \currentpdfbookmark{\c_@@_label_toc_tl}{ch:toc}
+        \currentpdfbookmark{\l_@@_toc_title_tl}{ch:toc}
       }
 
       % 制作目录

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2586,7 +2586,10 @@
           \newpage
         }
         {3} {
-          \linespread{1.26}\selectfont
+          \currentpdfbookmark{Statements}{frontmatter:originality}
+          \pagestyle{BIThesis}
+          \pagenumbering{gobble}
+
           % 原创性声明部分
           \begin{center}
             \vspace*{-2bp}
@@ -2597,7 +2600,7 @@
             }
           \end{center}~\par
 
-          % 本部分字号为小三
+          % 本部分字号为小四
           \zihao{-4}
           \c_@@_bachelor_english_label_originality_clause_tl
 
@@ -2605,7 +2608,7 @@
 
           Student~(Signature):~\dunderline[-1pt]{1pt}{\makebox[18mm]{}}~Date:\par
 
-          \vspace{6mm}
+          \vspace{\stretch{1}}
 
           % 使用授权声明部分
           \begin{center}

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -844,6 +844,10 @@
       { \flushbottom }
   },
   pageVerticalAlign .initial:n = {top},
+  non-CJK-font-in-headings .choice:,
+  non-CJK-font-in-headings / serif .code:n = { \bool_set_false:N \l_@@_arial_as_title_font_bool },
+  non-CJK-font-in-headings / sans .code:n = { \bool_set_true:N \l_@@_arial_as_title_font_bool },
+  non-CJK-font-in-headings .initial:n = {serif},
   % 数学字体配置
   mathFont .choices:nn = {
     asana, bonum, cm, concrete, dejavu, erewhon, euler,
@@ -1207,21 +1211,20 @@
       }
     }
 
-  \@@_if_thesis_english:TF {
+  \bool_if:NTF \l_@@_arial_as_title_font_bool {
+    % 手动指定时要加载 Arial
+    \newfontfamily\arialfamily{Arial}
+  } {
+    % 即使未指定，本科全英文专业模板的声明也需要 Arial
     \@@_if_thesis_int_type:nT {3} {
-      % 对于本科全英文专业模板
-      % Font Arial is needed.
       \newfontfamily\arialfamily{Arial}
     }
-
-  } {
-    % 对于其他的中文模板，
-    % 需要加载细黑体。
-    \tl_if_blank:VTF \l_@@_cover_xihei_font_path_tl {}
-    {
-      \setCJKfamilyfont{xihei}[AutoFakeBold,AutoFakeSlant]
-        {\l_@@_cover_xihei_font_path_tl}
-    }
+  }
+  % 无论中英文，封面都可能需要细黑体。
+  \tl_if_blank:VTF \l_@@_cover_xihei_font_path_tl {}
+  {
+    \setCJKfamilyfont{xihei}[AutoFakeBold,AutoFakeSlant]
+      {\l_@@_cover_xihei_font_path_tl}
   }
 
   % 对于本科全英文专业模板，需要自定义日期格式。
@@ -1341,9 +1344,9 @@
 % 定义标题字体。
 %    \begin{macrocode}
 \cs_new:Npn \l_@@_title_font_cs:n #1 {
-  \@@_if_thesis_int_type:nTF {3}
+  \bool_if:NTF \l_@@_arial_as_title_font_bool
   {
-    % 尽管是英文模板，但仍可能出现中文，因此需设置中文字体。
+    % 即使是英文模板，仍可能出现中文，也需设置中文字体。
     \heiti\arialfamily #1
   } {
     % 西文保持原本的 Times New Roman。黑体一般不搭配衬线体，但学校要求如此。

--- a/templates/paper-translation/main.tex
+++ b/templates/paper-translation/main.tex
@@ -18,7 +18,6 @@
 % The Current Maintainer of this work is Feng Kaiyu.
 %
 % Compile with: xelatex -> biber -> xelatex -> xelatex
-%%
 
 % !TeX program = xelatex
 % !BIB program = biber
@@ -29,9 +28,9 @@
 % 此处仅列出常用的配置。全部配置用法请见「bithesis.pdf」手册。
 \BITSetup{
   cover = {
-    % 在封面中载入有「北京理工大学」字样的图片，如无必要请勿改动。
+    % 封面需要「北京理工大学」字样图片，如无必要请勿修改该项。
     headerImage = images/header.png,
-    % 在封面标题中使用思源黑体，使用此选项可以保证与 Word 封面标题的字体一致。
+    % 封面标题需要“华文细黑”，如无必要请勿修改该项。
     xiheiFont = STXIHEI.TTF,
     % 官方模板采用了固定的下划线宽度。我们采用以下两个选项来达成这个效果。
     % 如果你想要使用自动计算的下划线宽度，也可以删去以下两个选项。
@@ -42,6 +41,7 @@
     title = 北京理工大学本科生毕业设计（论文）题目,
     titleEn = {The Subject of Undergraduate Graduation Project (Thesis) of Beijing Institute of Technology},
     % 注意，这里要写的是毕设的大标题，不是你要翻译的文献的标题。
+    %
     % 想要删除某项封面信息，直接删除该项即可。
     % 想要让某项封面信息留空（但是保留下划线），请传入空白符组成的字符串，如"{~}"。
     % 如需要换行，则用 “\\” 符号分割。
@@ -97,35 +97,31 @@
 \begin{document}
 
 % 标题页面：如无特殊需要，本部分无需改动
-% \input{misc/0_cover.tex}
 \MakeCover
 
-% 前置页面定义
+% 前置内容定义
 \frontmatter
-%\input{misc/1_originality.tex}
-% 摘要：在摘要相应的 TeX 文件处进行摘要部分的撰写
+% 摘要：在相应 TeX 文件撰写
 \input{chapters/0_abstract.tex}
-% 目录
+
 \MakeTOC
 
 % 正文开始
 \mainmatter
 
-% 第一章
+% 在这里引用各章 TeX 文件，按需添加
 \input{chapters/1_chapter1.tex}
-% 在这里添加第二章、第三章……TeX 文件的引用
-% \input{chapters/2_chapter2.tex}
-% \input{chapters/3_chapter3.tex}
 
-% 后置部分
+% 后置内容
 \backmatter
 
-% 结论：在结论相应的 TeX 文件处进行结论部分的撰写
+% 结论：在相应 TeX 文件撰写
 \input{misc/1_conclusion.tex}
-% 参考文献：如无特殊需要，参考文献相应的 TeX 文件无需改动，添加参考文献请使用 BibTeX 的格式
-%   添加至 misc/ref.bib 中，并在正文的相应位置使用 \cite{xxx} 的格式引用参考文献
+% 参考文献：
+% 添加文献时，请按 BibTeX 格式添加至 misc/ref.bib，并在正文所需位置使用 \cite{…} 引用。
+% 如无特殊需要，无需改动相应 TeX 文件。
 \input{misc/2_reference.tex}
-% 附录：在附录相应的 TeX 文件处进行附录部分的撰写
+% 附录：在相应 TeX 文件撰写；不需要时可删除
 \input{misc/3_appendix.tex}
 
 \end{document}

--- a/templates/reading-report/main.tex
+++ b/templates/reading-report/main.tex
@@ -28,12 +28,12 @@
 % 此处仅列出常用的配置。全部配置用法请见「bithesis.pdf」手册。
 \BITSetup{
   cover = {
-    % 在封面中载入有「北京理工大学」字样的图片，如无必要请勿改动。
+    % 封面需要「北京理工大学」字样图片，如无必要请勿修改该项。
     headerImage = images/header.png,
-    % 在封面标题中使用思源黑体，使用此选项可以保证与 Word 封面标题的字体一致。
+    % 封面标题需要“华文细黑”，如无必要请勿修改该项。
     xiheiFont = STXIHEI.TTF,
-    %% 使用以下参数来自定义封面日期
-    % date = 2023年6月,
+    % 可用以下参数自定义封面日期。
+    % date = 1955年11月,
   },
   info = {
     % 想要删除某项封面信息，直接删除该项即可。
@@ -54,6 +54,12 @@
     headline = 本科生读书报告,
     % 开启 Windows 平台下的中易宋体伪粗体。
     % windowsSimSunFakeBold = true,
+    %
+    % 开启该选项后，将用 Times New Roman 的开源字体 TeX Gyre Termes 作为正文字体。
+    % 这个选项适用于以下情况：
+    % 1. 不想在系统中安装 Times New Roman。
+    % 2. 在 Linux/macOS 下遇到 `\textsc` 无法正常显示的问题。
+    % betterTimesNewRoman = true,
   },
   misc = {
     % 微调表格行间距
@@ -84,19 +90,13 @@
 % 参考文献引用文件位于 misc/ref.bib
 \addbibresource{misc/ref.bib}
 
-% 如果要按照计算机学院的要求，
-% 在外文翻译报告中使用带有“北京理工大学”水印
-% 请使用此 issue 提供的方法：
-% https://github.com/BITNP/BIThesis/issues/350#issuecomment-1565974141
-
 % 文档开始
 \begin{document}
 
 % 标题页面：如无特殊需要，本部分无需改动
-% \input{misc/0_cover.tex}
 \MakeCover
 
-% 前置页面定义
+% 前置内容定义
 \frontmatter
 
 \MakeTOC
@@ -104,19 +104,18 @@
 % 正文开始
 \mainmatter
 
-% 第一章
+% 在这里引用各章 TeX 文件，按需添加
 \input{chapters/1_chapter1.tex}
-% 在这里添加第二章、第三章……TeX 文件的引用
 \input{chapters/2_chapter2.tex}
-% \input{chapters/3_chapter3.tex}
 
-% 后置部分
+% 后置内容
 \backmatter
 
-% 结论：在结论相应的 TeX 文件处进行结论部分的撰写
+% 结论：在相应 TeX 文件撰写
 \input{misc/1_conclusion.tex}
-% 参考文献：如无特殊需要，参考文献相应的 TeX 文件无需改动，添加参考文献请使用 BibTeX 的格式
-%   添加至 misc/ref.bib 中，并在正文的相应位置使用 \cite{xxx} 的格式引用参考文献
+% 参考文献：
+% 添加文献时，请按 BibTeX 格式添加至 misc/ref.bib，并在正文所需位置使用 \cite{…} 引用。
+% 如无特殊需要，无需改动相应 TeX 文件。
 \input{misc/2_reference.tex}
 
 \end{document}

--- a/templates/undergraduate-thesis-en/README.md
+++ b/templates/undergraduate-thesis-en/README.md
@@ -6,6 +6,105 @@
 
 > :warning: 重要提示：建议 macOS 用户使用最新版的 [texlive 2023](https://www.tug.org/mactex/mactex-download.html)，否则可能会遇到参考文献被查重的情况。详见 https://github.com/BITNP/BIThesis/issues/326
 
+## BITSetup 学院变体
+
+### 中文封面
+
+默认封面是英文，有些学院要求采用中文。这时请编辑`main.tex`，找到`\BITSetup{…}`，替换为以下内容。此外注意中文封面比英文封面多班号信息（`info/class`）。
+
+```latex
+\BITSetup{
+  % 以下三项切换封面为中文。
+  cover/prefer-zh = {true},
+  const/info/major = {专\qquad 业},
+  style/headline = {本科生毕业设计（论文）},
+  %
+  cover = {
+    % 封面需要「北京理工大学」字样图片，如无必要请勿修改该项。
+    headerImage = images/header.png,
+    % 封面标题需要“华文细黑”，如无必要请勿修改该项。
+    xiheiFont = STXIHEI.TTF,
+    % 可用以下参数自定义封面日期。
+    % date = 1955年11月,
+  },
+  info = {
+    % 想要删除某项封面信息，直接删除该项即可。
+    % 想要让某项封面信息留空（但是保留下划线），请传入空白符组成的字符串，如"{~}"。
+    % 如需要换行，则用 “\\” 符号分割。
+    title = 北京理工大学本科生毕业设计（论文）题目,
+    titleEn = {The Subject of Undergraduate Graduation Project (Thesis) of Beijing Institute of Technology},
+    school = 计算机学院,
+    major = 计算机科学与技术,
+    class = 0561xxxx,
+    author = 惠计算,
+    studentId = 11xxxxxxxx,
+    supervisor = 张哈希,
+    keywords = {北京理工大学；本科生；毕业设计（论文）——请在“main.tex”开头设置},
+    keywordsEn = {BIT; Undergraduate; Graduation Project (Thesis)},
+    % 如果你的毕设为校外毕设，请将下面这一行语句解除注释（删除第一个百分号字符）并填写你的校外毕设导师名字
+    % externalSupervisor = 左偏树,
+  },
+  style = {
+    % 页眉若要改为中文，请解除下一行的注释。
+    % head = {北京理工大学本科生毕业设计（论文）},
+    %
+    % 开启该选项后，将用 Times New Roman 的开源字体 TeX Gyre Termes 作为正文字体。
+    % 这个选项适用于以下情况：
+    % 1. 不想在系统中安装 Times New Roman。
+    % 2. 在 Linux/macOS 下遇到 `\textsc` 无法正常显示的问题。
+    % betterTimesNewRoman = true,
+  },
+  misc = {
+    % 微调表格行间距
+    tabularRowSeparation = 1.25,
+  },
+}
+```
+
+### 管理与经济学院
+
+经管学院还有些特殊要求，请：
+
+1. 编辑`main.tex`，按[上文](#中文封面)替换`\BITSetup{…}`。
+
+2. 在`\BITSetup{…}`的中，解除`style/head`的注释。
+
+3. 在`\BITSetup{…}`结尾，继续添加几项设置：
+
+    ```latex
+    \BITSetup{
+      …
+      misc = {…},
+      %
+      % 经管学院特殊要求：
+      %
+      % 调换中英文标题顺序
+      cover/reverse-titles = {true},
+      % 更改标题
+      TOC/title = {Contents}, % 删掉“Table of ”
+      appendices/title = {Appendix}, % 将“Appendices”改为单数
+      appendices/TOCTitle = {Appendix}, % 将“Appendices”改为单数
+    }
+    ```
+
+4. 编辑`chapters/0_abstract.tex`，调换`abstract`、`abstractEn`环境的顺序。
+
+    ```latex
+    % 先英文摘要
+    \begin{abstractEn}
+      …
+    \end{abstractEn}
+
+    % 再中文摘要
+    \begin{abstract}
+      …
+    \end{abstract}
+    ```
+
+此外，经管学院要求《原创性声明》《关于使用授权的声明》也是中文（而非双语）。
+
+- 盲审版要求删去声明，故不用考虑。
+- 答辩版、最终存档版要求声明有签字，可让 LaTeX 导入 PDF。到时请参考`main.tex`中“原创性声明”相关注释。
 
 ## 特性
 
@@ -64,8 +163,14 @@ latexmk
 
 ## 排版参考
 
+- 《北京理工大学本科生毕业设计（论文）书写规范及打印装订要求》
+- 《北京理工大学本科生毕业设计（论文）模板》
+- 《北京理工大学管理与经济学院本科生毕业设计（论文）模板（英文论文）》
+- 计算机学院《全英班论文封面》
 - 《本科-全英文 Thesis Format 2022》
 - 《本科-全英文 Thesis Sample 2021 with signature》
+
+此外还参考了信息与电子、集成电路与电子、机电等学院的通知。
 
 [^1]: 关于如何升级模板的版本，请参考[手册][manual]中「版本号与升级」这一章节内容。
 

--- a/templates/undergraduate-thesis-en/chapters/0_abstract.tex
+++ b/templates/undergraduate-thesis-en/chapters/0_abstract.tex
@@ -21,6 +21,8 @@
 %
 % https://github.com/BITNP/BIThesis
 
+% 摘要若要按经管学院的要求，先英文再中文，请调换以下 abstract、abstractEn 的顺序。
+
 \begin{abstract}
   Conventional  product  development  employs  a  design-build-test  philosophy.
   The sequentially  executed  development  process  often  results  in  prolonged

--- a/templates/undergraduate-thesis-en/main.tex
+++ b/templates/undergraduate-thesis-en/main.tex
@@ -106,11 +106,16 @@
 % 标题页面：如无特殊需要，本部分无需改动
 \MakeCover
 
+% 原创性声明：盲审结束前无需改动
+\MakeOriginality
+% 后续添加签名时，可考虑先用 Word 制作再导出到 misc/0_originality.pdf，
+% 同时注释以上 `\MakeOriginality`，解除注释以下三行代码。
+% \begin{blindPeerReview}
+%   \includepdf{misc/0_originality.pdf}\newpage
+% \end{blindPeerReview}
+
 % 前置内容定义
 \frontmatter
-
-\MakeOriginality
-
 % 摘要：在相应 TeX 文件撰写
 \input{chapters/0_abstract.tex}
 

--- a/templates/undergraduate-thesis-en/main.tex
+++ b/templates/undergraduate-thesis-en/main.tex
@@ -18,7 +18,6 @@
 % The Current Maintainer of this work is Feng Kaiyu.
 %
 % Compile with: xelatex -> biber -> xelatex -> xelatex
-%%
 
 % !TeX program = xelatex
 % !BIB program = biber
@@ -35,8 +34,8 @@
     headerImage = images/header.png,
     % 封面标题需要“华文细黑”，如无必要请勿修改该项。
     xiheiFont = STXIHEI.TTF,
-    % 修改封面日期
-    % date = May 31 2023,
+    % 可用以下参数自定义封面日期。
+    % date = {November 5, 1955},
   },
   info = {
     % 想要删除某项封面信息，直接删除该项即可。
@@ -55,11 +54,14 @@
     % externalSupervisor = 左偏树,
   },
   style = {
-    % 保持参考文献的缩进样式与 Word 模板一致。
-    % 如果你不需要此样式，请将此行注释掉。
-    bibliographyIndent = false,
-    % 如无必要请勿修改该项。
-    % head = {自定义页眉文字}
+    % 页眉若要改为中文，请解除下一行的注释。
+    % head = {北京理工大学本科生毕业设计（论文）},
+    %
+    % 开启该选项后，将用 Times New Roman 的开源字体 TeX Gyre Termes 作为正文字体。
+    % 这个选项适用于以下情况：
+    % 1. 不想在系统中安装 Times New Roman。
+    % 2. 在 Linux/macOS 下遇到 `\textsc` 无法正常显示的问题。
+    % betterTimesNewRoman = true,
   },
   misc = {
     % 微调表格行间距
@@ -69,10 +71,12 @@
 
 % 使用 listings 宏包进行代码块使用，并使用了预定义的样式，
 % 你也可以选用自己的喜欢的其他宏包，如 minted；
-% 然而由于 minted 依赖 Python 的 Pygments 库作为外部依赖，因此出于模板的建议性考虑，我们没有提供 minted 进行代码块书写的示例。
-% 但是，我们仍旧非常建议你使用 minted。
+% 然而由于 minted 依赖 Python 的 Pygments 库作为外部依赖，因此出于模板的简洁程度考虑，我们没有提供 minted 进行代码块书写的示例。
 \usepackage{listings}
 
+
+% 大部分关于参考文献样式的修改，都可以通过此处的选项进行配置。
+% 详情请搜索「biblatex-gb7714-2015 文档」进行阅读。
 \usepackage[
   backend=biber,
   style=gb7714-2015,
@@ -95,15 +99,14 @@
 \begin{document}
 
 % 标题页面：如无特殊需要，本部分无需改动
-% \input{misc/0_cover.tex}
 \MakeCover
 
-% 前置页面定义
+% 前置内容定义
 \frontmatter
 
 \MakeOriginality
 
-% 摘要：在摘要相应的 TeX 文件处进行摘要部分的撰写
+% 摘要：在相应 TeX 文件撰写
 \input{chapters/0_abstract.tex}
 
 \MakeTOC
@@ -111,23 +114,23 @@
 % 正文开始
 \mainmatter
 
-% 第一章
+% 在这里引用各章 TeX 文件，按需添加
 \input{chapters/1_chapter1.tex}
-% 在这里添加第二章、第三章的 TeX 文件的引用
 \input{chapters/2_chapter2.tex}
 \input{chapters/3_chapter3.tex}
 
 % 后置内容
 \backmatter
 
-% 结论：在结论相应的 TeX 文件处进行结论部分的撰写
+% 结论：在相应 TeX 文件撰写
 \input{misc/1_conclusions.tex}
-% 参考文献：如无特殊需要，参考文献相应的 TeX 文件无需改动，添加参考文献请使用 BibTeX 的格式
-%   添加至 misc/ref.bib 中，并在正文的相应位置使用 \cite{xxj} 的格式引用参考文献
+% 参考文献：
+% 添加文献时，请按 BibTeX 格式添加至 misc/ref.bib，并在正文所需位置使用 \cite{…} 引用。
+% 如无特殊需要，无需改动相应 TeX 文件。
 \input{misc/2_references.tex}
-% 附录：在附录相应的 TeX 文件处进行附录部分的撰写
+% 附录：在相应 TeX 文件撰写；不需要时可删除
 \input{misc/3_appendices.tex}
-% 致谢：在致谢相应的 TeX 文件处进行致谢部分的撰写
+% 致谢：在相应 TeX 文件撰写
 \input{misc/4_acknowledgements.tex}
 
 \end{document}

--- a/templates/undergraduate-thesis-en/main.tex
+++ b/templates/undergraduate-thesis-en/main.tex
@@ -67,6 +67,11 @@
     % 微调表格行间距
     tabularRowSeparation = 1.25,
   },
+  const = {
+    % 有些专业名带上“Bachelor of…”太长，学院可能建议把 degree 改成 major。
+    % 若要将封面的“Degree:”改为“Major:”，请解除下一行的注释。
+    % info/major = {Major},
+  },
 }
 
 % 使用 listings 宏包进行代码块使用，并使用了预定义的样式，

--- a/templates/undergraduate-thesis-en/main.tex
+++ b/templates/undergraduate-thesis-en/main.tex
@@ -27,6 +27,7 @@
 
 \documentclass[type=bachelor_english]{bithesis}
 
+% 若需中文封面或在经管学院，请参考 ./README.md 中「BITSetup 学院变体」一节。
 % 此处仅列出常用的配置。全部配置用法请见「bithesis.pdf」手册。
 \BITSetup{
   cover = {
@@ -53,6 +54,10 @@
     % 如果你的毕设为校外毕设，请将下面这一行语句解除注释（删除第一个百分号字符）并填写你的校外毕设导师名字
     % externalSupervisor = 左偏树,
   },
+  % 有些专业名带上“Bachelor of…”太长，学院可能建议把 degree 改成 major。
+  % 若要将封面的“Degree:”改为“Major:”，请解除下一行的注释。
+  % const/info/major = {Major},
+  %
   style = {
     % 页眉若要改为中文，请解除下一行的注释。
     % head = {北京理工大学本科生毕业设计（论文）},
@@ -67,18 +72,6 @@
     % 微调表格行间距
     tabularRowSeparation = 1.25,
   },
-  const = {
-    % 有些专业名带上“Bachelor of…”太长，学院可能建议把 degree 改成 major。
-    % 若要将封面的“Degree:”改为“Major:”，请解除下一行的注释。
-    % info/major = {Major},
-  },
-  %
-  % 标题若要按经管学院的要求，请解除以下几行的注释。
-  % % 将“Appendices”改为单数：
-  % appendices/title = {Appendix},
-  % appendices/TOCTitle = {Appendix},
-  % % 删掉“Table of ”：
-  % TOC/title = {Contents},
 }
 
 % 使用 listings 宏包进行代码块使用，并使用了预定义的样式，

--- a/templates/undergraduate-thesis-en/main.tex
+++ b/templates/undergraduate-thesis-en/main.tex
@@ -72,6 +72,10 @@
     % 若要将封面的“Degree:”改为“Major:”，请解除下一行的注释。
     % info/major = {Major},
   },
+  %
+  % 若要将“Appendices”改为单数，请解除以下两行的注释：
+  % appendices/title = {Appendix},
+  % appendices/TOCTitle = {Appendix},
 }
 
 % 使用 listings 宏包进行代码块使用，并使用了预定义的样式，

--- a/templates/undergraduate-thesis-en/main.tex
+++ b/templates/undergraduate-thesis-en/main.tex
@@ -73,9 +73,12 @@
     % info/major = {Major},
   },
   %
-  % 若要将“Appendices”改为单数，请解除以下两行的注释：
+  % 标题若要按经管学院的要求，请解除以下几行的注释。
+  % % 将“Appendices”改为单数：
   % appendices/title = {Appendix},
   % appendices/TOCTitle = {Appendix},
+  % % 删掉“Table of ”：
+  % TOC/title = {Contents},
 }
 
 % 使用 listings 宏包进行代码块使用，并使用了预定义的样式，

--- a/templates/undergraduate-thesis/main.tex
+++ b/templates/undergraduate-thesis/main.tex
@@ -102,16 +102,13 @@
 % 标题页面：如无特殊需要，本部分无需改动
 \MakeCover
 
-% 原创性声明：如无特殊需要，本部分无需改动
-% 更改为 PDF 页面插入，如需要添加内容，可考虑先用 Word 制作再覆盖 misc/1_originality.pdf
-% ====== 原创性声明（PDF 格式）======
+% 原创性声明：盲审结束前无需改动
+% 后续添加签名时，可考虑先用 Word 制作再覆盖 misc/1_originality.pdf。
+% 不过如无特殊需要，本部分的代码仍无需改动。
 \begin{blindPeerReview}
   \includepdf{misc/1_originality.pdf}\newpage
 \end{blindPeerReview}
-% ====== 原创性声明（PDF 格式）======
-% ====== 原创性声明（LaTeX 格式）======
-% \input{./misc/1_originality.tex}
-% ====== 原创性声明（LaTeX 格式）======
+% \input{misc/1_originality.tex}
 
 % 前置内容定义
 \frontmatter

--- a/templates/undergraduate-thesis/main.tex
+++ b/templates/undergraduate-thesis/main.tex
@@ -1,5 +1,5 @@
 %%
-% The BIThesis Template for Bachelor Graduation Thesis
+% The BIThesis Template for Undergraduate Thesis
 %
 % 北京理工大学毕业设计（论文） —— 使用 XeLaTeX 编译
 %
@@ -30,12 +30,12 @@
 % 此处仅列出常用的配置。全部配置用法请见「bithesis.pdf」手册。
 \BITSetup{
   cover = {
-    % 在封面中载入有「北京理工大学」字样的图片，如无必要请勿改动。
+    % 封面需要「北京理工大学」字样图片，如无必要请勿修改该项。
     headerImage = images/header.png,
-    % 在封面标题中使用思源黑体，使用此选项可以保证与 Word 封面标题的字体一致。
+    % 封面标题需要“华文细黑”，如无必要请勿修改该项。
     xiheiFont = STXIHEI.TTF,
-    %% 使用以下参数来自定义封面日期
-    % date = 2022年6月,
+    % 可用以下参数自定义封面日期。
+    % date = 1955年11月,
   },
   info = {
     % 想要删除某项封面信息，直接删除该项即可。
@@ -57,6 +57,7 @@
   style = {
     % 开启 Windows 平台下的中易宋体伪粗体。
     % windowsSimSunFakeBold = true,
+    %
     % 开启该选项后，将用 Times New Roman 的开源字体 TeX Gyre Termes 作为正文字体。
     % 这个选项适用于以下情况：
     % 1. 不想在系统中安装 Times New Roman。
@@ -99,7 +100,6 @@
 \begin{document}
 
 % 标题页面：如无特殊需要，本部分无需改动
-% \input{misc/0_cover.tex}
 \MakeCover
 
 % 原创性声明：如无特殊需要，本部分无需改动
@@ -113,9 +113,9 @@
 % \input{./misc/1_originality.tex}
 % ====== 原创性声明（LaTeX 格式）======
 
-% 前置页面定义
+% 前置内容定义
 \frontmatter
-% 摘要：在摘要相应的 TeX 文件处进行摘要部分的撰写
+% 摘要：在相应 TeX 文件撰写
 \input{chapters/0_abstract.tex}
 
 \MakeTOC
@@ -123,23 +123,22 @@
 % 正文开始
 \mainmatter
 
-% 第一章
+% 在这里引用各章 TeX 文件，按需添加
 \input{chapters/1_chapter1.tex}
-% 在这里添加第二章、第三章……TeX 文件的引用
 \input{chapters/2_chapter2.tex}
-% \input{chapters/3_chapter3.tex}
 
-% 后置部分
+% 后置内容
 \backmatter
 
-% 结论：在结论相应的 TeX 文件处进行结论部分的撰写
+% 结论：在相应 TeX 文件撰写
 \input{misc/2_conclusion.tex}
-% 参考文献：如无特殊需要，参考文献相应的 TeX 文件无需改动，添加参考文献请使用 BibTeX 的格式
-%   添加至 misc/ref.bib 中，并在正文的相应位置使用 \cite{xxx} 的格式引用参考文献
+% 参考文献：
+% 添加文献时，请按 BibTeX 格式添加至 misc/ref.bib，并在正文所需位置使用 \cite{…} 引用。
+% 如无特殊需要，无需改动相应 TeX 文件。
 \input{misc/3_reference.tex}
-% 附录：在附录相应的 TeX 文件处进行附录部分的撰写
+% 附录：在相应 TeX 文件撰写；不需要时可删除
 \input{misc/4_appendix.tex}
-% 致谢：在致谢相应的 TeX 文件处进行致谢部分的撰写
+% 致谢：在相应 TeX 文件撰写
 \input{misc/5_acknowledgements.tex}
 
 \end{document}


### PR DESCRIPTION
更改繁杂，请查看提交记录。

Resolves #496

- [x] 完整测试
- ~~引入了若干只有个别模板适用的选项。选项不适用时，也许有必要[用 l3msg 警告](https://tex.stackexchange.com/questions/246810/latex3-l3msg-best-practices)？~~ 大约一般人不会凭空加选项。
- [x] 统一英文模板的名称。手册并没全用`\BIThesisTemplates{UTE}`，有好几种说法，不易搜索。
- ~~问一下经管学院的同学。~~ 太久没回复。

## 回归测试

### undergraduate-thesis-en

[diff.pdf](https://github.com/user-attachments/files/16179682/diff.pdf)

[经管学院版](https://github.com/user-attachments/files/16179806/main.pdf)

### 其它变化

![图片](https://github.com/BITNP/BIThesis/assets/73375426/17bf8a96-3ada-45c9-972f-54b701b8873d)

![图片](https://github.com/BITNP/BIThesis/assets/73375426/75d8cfa8-918a-48b8-9610-108265ea9a9d)
