### PR TITLE
fix: 硕博模板中`cover/hideCoverInPeerReview`应仍默认为 false

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -694,9 +694,9 @@ underlineOffset = (*(-10pt)|\marg{任意长度}*)
   设置封面信息中下划线的偏移量。
 \end{function}
 
-\begin{function}[added=2023-05-09, updated=2024-06-14]{cover/hideCoverInPeerReview}
+\begin{function}[added=2023-05-09, updated=2024-08-28]{cover/hideCoverInPeerReview}
 \begin{bitsyntax}[emph={[1]hideCoverInPeerReview}]
-hideCoverInPeerReview = (*(from-thesis-type)|false|true*)
+hideCoverInPeerReview = (*false|true*)
 \end{bitsyntax}
 
   \textit{此选项默认值会按论文类型自动设置，一般已满足要求，不需要用户自行修改。}
@@ -706,7 +706,7 @@ hideCoverInPeerReview = (*(from-thesis-type)|false|true*)
   \begin{itemize}
     \item 若设为 |true|，盲审模式下直接删除封面。
     \item 若设为 |false|，盲审模式下保留封面，只是隐去个人信息。
-    \item （默认）若设为 |from-thesis-type|，自动根据论文类型设置。具体来说，本科生设为 |true|，研究生设为 |false|。
+    \item （默认）若未设置，自动根据论文类型设置。具体来说，本科生设为 |true|，研究生设为 |false|。
   \end{itemize}
 
   未启用盲审模式时，此选项无效果。

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -615,17 +615,9 @@
     underlineThickness .initial:n = {1pt},
     underlineOffset .dim_set:N = \l_@@_cover_underline_offset_dim,
     underlineOffset .initial:n = { -10pt },
-    hideCoverInPeerReview .choice:,
-    hideCoverInPeerReview / true .code:n = { \bool_set_true:N \l_@@_cover_hide_cover_in_peer_review_bool },
-    hideCoverInPeerReview / false .code:n = { \bool_set_false:N \l_@@_cover_hide_cover_in_peer_review_bool },
-    hideCoverInPeerReview / from-thesis-type .code:n = {
-      \@@_if_graduate:TF {
-        \bool_set_false:N \l_@@_cover_hide_cover_in_peer_review_bool
-      } {
-        \bool_set_true:N \l_@@_cover_hide_cover_in_peer_review_bool
-      }
-    },
-    hideCoverInPeerReview .initial:n = {from-thesis-type},
+    hideCoverInPeerReview .bool_set:N = \l_@@_cover_hide_cover_in_peer_review_bool,
+    % 此处暂且填充默认值为`false`，待确定`\g_@@_thesis_type_int`后再根据论文类型覆盖默认值
+    hideCoverInPeerReview .initial:n = {false},
     % 研究生的「特殊类型」
     showSpecialTypeBox .bool_set:N = \l_@@_cover_show_special_type_box_bool,
     showSpecialTypeBox .initial:n = {false},
@@ -935,6 +927,14 @@
 % 宏包的模板选项可以在宏加载时生效。
 %    \begin{macrocode}
 \ProcessKeysOptions { bithesis / option }
+%    \end{macrocode}
+% 确定 |bithesis/option| 中的 |\g_@@_thesis_type_int| 后，根据论文类型自动覆盖某些选项的默认值。
+%    \begin{macrocode}
+\@@_if_graduate:TF {
+  \keys_set:nn {bithesis} {cover/hideCoverInPeerReview = false}
+} {
+  \keys_set:nn {bithesis} {cover/hideCoverInPeerReview = true}
+}
 %    \end{macrocode}
 %
 % \subsubsection{处理模板选项}


### PR DESCRIPTION
重新实现了 #533 的 286fa7003888dfd65686925fef1d3ee519b714b4。当时只验证了本科模板，没想到由于 LaTeX 的奇葩机制，误改了硕博模板。

Fixes #548

### 测试结果

| `\documentclass[type = …]{bithesis}` | `\BITSetup{…}`                        | `\l_@@_cover_hide_cover_in_peer_review_bool` |
| ------------------------------------ | ------------------------------------- | -------------------------------------------- |
| `master`                             | 空 | false（此PR前是true，之前发布版是false）                 |                                              
| `master`                             | `cover/hideCoverInPeerReview = false` | false                                        |
| `master`                             | `cover/hideCoverInPeerReview = true`  | false → true                                 |
| `bachelor`                           | 空                                    | true（此PR前是true，之前发布版是false）                                         |
| `bachelor`                           | `cover/hideCoverInPeerReview = false` | true → false                                 |
| `bachelor`                           | `cover/hideCoverInPeerReview = true`  | true                                         |

```latex
% !TeX program = xelatex
% !BIB program = biber

\documentclass[type=bachelor,twoside=false]{bithesis}

\ExplSyntaxOn
\message{DEBUG:~before~BITSetup}
\bool_log:N \l__bithesis_cover_hide_cover_in_peer_review_bool
\ExplSyntaxOff

% \BITSetup{cover/hideCoverInPeerReview = false}

\ExplSyntaxOn
\message{DEBUG:~after~BITSetup}
\bool_log:N \l__bithesis_cover_hide_cover_in_peer_review_bool
\ExplSyntaxOff


\begin{document}

\MakeCover
\MakePaperBack
\MakeTitle
\MakeOriginality

\frontmatter
\input{./chapters/abstract.tex}

\end{document}
```

