### PR TITLE
ci: Fix release notes of pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
         id: git-cliff
         with:
           config: cliff.toml
-          args: -vv --latest --strip header
+          args: -vv ${{ github.event.release.prerelease && '--unreleased' || '--latest' }} --strip header
         env:
           OUTPUT: CHANGES.md
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
之前 https://github.com/BITNP/BIThesis/releases/tag/v3.7.10-alpha-1 的内容是 v3.7.9，对不上。现在针对 pre-releases 从`--latest`改用`--unreleased`。

```bash
$ git cliff --help
…
  -l, --latest          Processes the commits starting from the latest tag
      --current         Processes the commits that belong to the current tag
  -u, --unreleased      Processes the commits that do not belong to a tag
…
```

参考了 https://github.com/search?q=orhun%2Fgit-cliff-action+path%3A.github%2Fworkflows%2F+language%3AYAML+repo%3Aratatui%2Fratatui&type=code&s=indexed&o=desc ，他们`release-alpha.yml`采用`--unreleased`，`release-stable.yml`采用`--latest`。
