### PR TITLE
feat: 本科毕设英文模板封面按照要求加入中文标题

### DIFF
--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -743,6 +743,16 @@ reverse-titles = (*(false)|true*)
   不适用于\BIThesisTemplates{PT}和硕士、博士学位论文。
 \end{function}
 
+\begin{function}[added=2024-09-14]{cover/addTitleZh}
+\begin{bitsyntax}[emph={[1]addTitleZh}]
+addTitleZh = (*(true)|false*)
+\end{bitsyntax}
+
+  是否添加中文标题，只适用于本科英文封面。
+
+  只适用于\BIThesisTemplates{UTE}，不适用于其它模板。而且若切换为中文封面（|cover/prefer-zh = true|），此选项也无效。
+\end{function}
+
 \subsubsection{论文基本信息}
 
 \begin{function}{info}

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -627,6 +627,9 @@
     % 本科英文模板使用中文封面时可能需要调换中英文标题顺序
     reverse-titles .bool_set:N = \l_@@_cover_reverse_titles_bool,
     reverse-titles .initial:n = {false},
+    % 本科英文模板需要加入中文标题
+    addTitleZh .bool_set:N = \l_@@_cover_add_titlezh_bool,
+    addTitleZh .initial:n = {true},
   }
 %    \end{macrocode}
 %
@@ -2512,6 +2515,11 @@
           \zihao{1}\textbf{\ziju{0.12}\l_@@_style_headline_tl}\par
 
           \vspace{18mm}
+
+          \bool_if:NT \l_@@_cover_add_titlezh_bool {
+            \zihao{2}\textbf{\xihei:n \l_@@_value_title_tl}\par
+            \vspace{16mm}
+          }
 
           \zihao{2}\textbf{\xihei:n \l_@@_value_title_en_tl}\par
 

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -627,7 +627,7 @@
     % 本科英文模板使用中文封面时可能需要调换中英文标题顺序
     reverse-titles .bool_set:N = \l_@@_cover_reverse_titles_bool,
     reverse-titles .initial:n = {false},
-    % 本科英文模板需要加入中文标题
+    % 本科英文模板可加入中文标题
     addTitleZh .bool_set:N = \l_@@_cover_add_titlezh_bool,
     addTitleZh .initial:n = {true},
   }

--- a/templates/undergraduate-thesis-en/README.md
+++ b/templates/undergraduate-thesis-en/README.md
@@ -8,6 +8,23 @@
 
 ## BITSetup 学院变体
 
+### 英文封面隐藏中文标题
+
+默认封面虽是英文，但也有中文标题。如果您想隐藏封面的中文标题，请编辑`main.tex`，找到`\BITSetup{…}`，设置`cover/addTitleZh = false`：
+
+```latex
+\BITSetup{
+  cover = {
+    …
+    % date = {November 5, 1955},
+    addTitleZh = false,
+  },
+  …
+}
+```
+
+另外注意，即使封面隐藏了中文标题，中文摘要也有，故仍需在`info/title`填写中文标题信息。
+
 ### 中文封面
 
 默认封面是英文，有些学院要求采用中文。这时请编辑`main.tex`，找到`\BITSetup{…}`，替换为以下内容。此外注意中文封面比英文封面多班号信息（`info/class`）。


### PR DESCRIPTION
* 在本科毕设英文模板封面（英文模式）中的英文标题之上增加了中文标题，以符合论文抽检系统要求。
![image](https://github.com/user-attachments/assets/5f5fd62a-de5a-48e2-b77b-e7912667f5da)
