### PR TITLE
docs: 给`titleEn`示例添加括号

### DIFF
--- a/templates/graduate-thesis/main.tex
+++ b/templates/graduate-thesis/main.tex
@@ -52,7 +52,7 @@
     % 如需覆盖竖排标题，请配置以下选项。
     % 下面的例子展示了如何在竖排标题中使用垂直或者旋转的英文。
     % verticalTitle = {形状记忆聚氨酯{L } {T } {X }的合成 \rotatebox[origin=c]{-90}{Feng Kaiyu} 及其在织物中的应用},
-    titleEn = Synthesis and Application on textile of the Shape Memory Polyurethane,
+    titleEn = {Synthesis and Application on textile of the Shape Memory Polyurethane},
     author = 张三,
     % 如果想要手动控制盲审模式下的隐藏信息，可以使用宏 \SecretInfo{}。使用方式有两种，如：
     % major = \SecretInfo{材料科学与工程} 可以得到 ******* （用等量的替换符号替代）

--- a/templates/undergraduate-thesis-en/main.tex
+++ b/templates/undergraduate-thesis-en/main.tex
@@ -43,7 +43,7 @@
     % 想要让某项封面信息留空（但是保留下划线），请传入空白符组成的字符串，如"{~}"。
     % 如需要换行，则用 “\\” 符号分割。
     title = 你的论文标题（中文）,
-    titleEn = Your Thesis Title,
+    titleEn = {Your Thesis Title},
     school = School of Mechanical Engineering,
     major = Bachelor of Science in Mechanical Engineering,
     author = Feng Kaiyu,


### PR DESCRIPTION
`\BITSetup`（l3keys）使用`,`分隔。如果标题本身就含`,`，必须用括号包裹，不然无法正常解析。

这并不显然。给示例加上括号，可以让一般人也能猜到。

（今天群里有人问，上学期我也被别人问过。）

<details>
<summary>Typst 的样子</summary>

[charged-ieee – Typst Universe](https://typst.app/universe/package/charged-ieee)

```typst
#import "@preview/charged-ieee:0.1.3": ieee

#show: ieee.with(
  title: [A typesetting system to untangle the scientific writing process],
  abstract: [
    The process of scientific writing is often tangled up with the intricacies of typesetting, leading to frustration and wasted time for researchers. In this paper, we introduce Typst, a new typesetting system designed specifically for scientific writing. Typst untangles the typesetting process, allowing researchers to compose papers faster. In a series of experiments we demonstrate that Typst offers several advantages, including faster document creation, simplified syntax, and increased ease-of-use.
  ],
  authors: (
    (
      name: "Martin Haug",
      department: [Co-Founder],
      organization: [Typst GmbH],
      location: [Berlin, Germany],
      email: "haug@typst.app"
    ),
    (
      name: "Laurenz Mädje",
      department: [Co-Founder],
      organization: [Typst GmbH],
      location: [Berlin, Germany],
      email: "maedje@typst.app"
    ),
  ),
  index-terms: ("Scientific writing", "Typesetting", "Document creation", "Syntax"),
  bibliography: bibliography("refs.bib"),
)

// Your content goes below.
```

</details>