### PR TITLE
ci: Fix packages

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -1,3 +1,5 @@
+# ----- 1. 编译基础中文文档需要 -----
+
 scheme-minimal
 
 collection-latex
@@ -15,6 +17,8 @@ biber
 biblatex
 biblatex-gb7714-2015
 
+# ----- 2. 编译 templates/* 需要 -----
+
 # collection-latexextra
 enumitem
 fmtcount
@@ -22,6 +26,7 @@ multirow
 titlesec
 xint # indirect
 xstring # indirect
+mwe # for `example-image*` files
 
 # collection-latexrecommended
 booktabs
@@ -48,3 +53,25 @@ xits
 
 # collection-fontsrecommended
 tex-gyre
+
+# Not included in any collection
+float
+
+# ----- 3. 编译 handbook 和 bithesis.pdf 需要 -----
+
+# collection-latexextra
+adjustbox # indirect
+alphalph # indirect
+awesomebox
+csquotes # indirect
+csvsimple # indirect
+framed
+hypdoc
+markdown
+menukeys
+relsize
+was # for upgreek
+wrapfig
+
+# Not included in any collection
+fancyvrb # indirect


### PR DESCRIPTION
Resolves https://github.com/BITNP/BIThesis/pull/607#issuecomment-2775919346

之前测试时在逐步缩小范围，但有缓存。有些关键宏包即使被删除了，缓存里也有，所以仍能编译。

<details><summary>测试脚本</summary>

```patch
From f6079c6cec99b856d56abbf0848f1a821f6e0c44 Mon Sep 17 00:00:00 2001
From: "Y.D.X." <73375426+YDX-2147483647@users.noreply.github.com>
Date: Thu, 3 Apr 2025 23:59:40 +0800
Subject: [PATCH] temporary scripts

---
 Makefile                     |  2 +-
 packages.txt                 | 50 ++++++++++++++++++++++++++++++++++++
 scripts/minimize_packages.py | 31 ++++++++++++++++++++++
 scripts/test.py              | 20 +++++++--------
 4 files changed, 92 insertions(+), 11 deletions(-)
 create mode 100644 packages.txt
 create mode 100644 scripts/minimize_packages.py

diff --git a/Makefile b/Makefile
index 973a2c4..fc0a1a1 100644
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 .PHONY: all FORCE_MAKE
 
 $(PACKAGE).pdf: cls assets/faq.tex FORCE_MAKE
-	@$(LATEXMK) -xelatex $(PACKAGE).dtx
+	@$(LATEXMK) -xelatex $(PACKAGE).dtx -g -silent
 
 $(CLSFILE): $(SOURCES)
 	yes y | xetex $(PACKAGE).ins
diff --git a/packages.txt b/packages.txt
new file mode 100644
index 0000000..42a28db
--- /dev/null
+++ b/packages.txt
@@ -0,0 +1,50 @@
+🔍 Trying to compile without alphalph.
+The package alphalph is necessary.
+🔍 Trying to compile without csquotes.
+The package csquotes is necessary.
+🔍 Trying to compile without hypdoc.
+The package hypdoc is necessary.
+🔍 Trying to compile without wrapfig.
+The package wrapfig is necessary.
+🔍 Trying to compile without awesomebox.
+The package awesomebox is necessary.
+🔍 Trying to compile without markdown.
+The package markdown is necessary.
+🔍 Trying to compile without csvsimple.
+The package csvsimple is necessary.
+🔍 Trying to compile without framed.
+The package framed is necessary.
+🔍 Trying to compile without menukeys.
+The package menukeys is necessary.
+🔍 Trying to compile without adjustbox.
+The package adjustbox is necessary.
+🔍 Trying to compile without relsize.
+The package relsize is necessary.
+🔍 Trying to compile without was.
+The package was is necessary.
+🔍 Trying to compile without subfigure.
+🔮 The package subfigure is redundant!
+🔍 Trying to compile without threeparttablex.
+🔮 The package threeparttablex is redundant!
+🔍 Trying to compile without threeparttable.
+🔮 The package threeparttable is redundant!
+🔍 Trying to compile without mwe.
+The package mwe is necessary.
+🔍 Trying to compile without tabu.
+🔮 The package tabu is redundant!
+🔍 Trying to compile without catchfile.
+🔮 The package catchfile is redundant!
+🔍 Trying to compile without datetime2.
+🔮 The package datetime2 is redundant!
+🔍 Trying to compile without ifoddpage.
+🔮 The package ifoddpage is redundant!
+🔍 Trying to compile without xint.
+The package xint is necessary.
+🔍 Trying to compile without minted.
+🔮 The package minted is redundant!
+🔍 Trying to compile without datetime2-english.
+🔮 The package datetime2-english is redundant!
+🔍 Trying to compile without bigfoot.
+🔮 The package bigfoot is redundant!
+🔍 Trying to compile without cprotect.
+🔮 The package cprotect is redundant!
diff --git a/scripts/minimize_packages.py b/scripts/minimize_packages.py
new file mode 100644
index 0000000..e126202
--- /dev/null
+++ b/scripts/minimize_packages.py
@@ -0,0 +1,31 @@
+from shutil import which
+from subprocess import run
+from typing import Any
+
+
+def log(message: str | Any) -> None:
+    """Write to stdout and the SUMMARY file."""
+    if not isinstance(message, str):
+        message = str(message)
+
+    print(message)
+    with open("packages.txt", "a", encoding="utf-8") as f:
+        f.write(message + "\n")
+
+
+tlmgr = which("tlmgr")
+assert tlmgr is not None
+
+packages = "alphalph csquotes hypdoc wrapfig awesomebox markdown csvsimple framed menukeys adjustbox relsize was subfigure threeparttablex threeparttable mwe tabu catchfile datetime2 ifoddpage xint minted datetime2-english bigfoot cprotect".split()
+
+for p in packages:
+    log(f"🔍 Trying to compile without {p}.")
+    run([tlmgr, "uninstall", p], check=True)
+
+    result = run(["make", "test"])
+    if result.returncode == 0:
+        log(f"🔮 The package {p} is redundant!")
+    else:
+        log(f"The package {p} is necessary.")
+
+    run([tlmgr, "install", p], check=True)
diff --git a/scripts/test.py b/scripts/test.py
index 585cd0d..8c499fb 100644
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -61,7 +61,7 @@ class TestCase:
         /,
         *,
         name: str | None = None,
-        args: list[str] = ["latexmk", "-g"],
+        args: list[str] = ["latexmk", "-g", "-silent"],
         env: dict[str, str] | None = None,
     ) -> None:
         assert directory.exists()
@@ -95,21 +95,21 @@ class TestCase:
                         ]
                     )
                 )
-            return running_error
+            raise running_error
 
         duration = perf_counter() - start
         log(f"✅{self.icon} 可正常编译 {self.name}：⌛ {duration:.1f} 秒。")
 
 
 TESTS = [
-    TestCase("📁", SCAFFOLD_DIR / "undergraduate-thesis"),
-    TestCase("📁", SCAFFOLD_DIR / "paper-translation"),
-    TestCase("📁", SCAFFOLD_DIR / "graduate-thesis"),
-    TestCase("📁", SCAFFOLD_DIR / "reading-report"),
-    TestCase("📁", SCAFFOLD_DIR / "lab-report"),
-    TestCase("📁", SCAFFOLD_DIR / "presentation-slide"),
-    TestCase("🧪", TEST_DIR / "doctor-thesis"),
-    TestCase("🧪", TEST_DIR / "autorefs"),
+    # TestCase("📁", SCAFFOLD_DIR / "undergraduate-thesis"),
+    # TestCase("📁", SCAFFOLD_DIR / "paper-translation"),
+    # TestCase("📁", SCAFFOLD_DIR / "graduate-thesis"),
+    # TestCase("📁", SCAFFOLD_DIR / "reading-report"),
+    # TestCase("📁", SCAFFOLD_DIR / "lab-report"),
+    # TestCase("📁", SCAFFOLD_DIR / "presentation-slide"),
+    # TestCase("🧪", TEST_DIR / "doctor-thesis"),
+    # TestCase("🧪", TEST_DIR / "autorefs"),
     TestCase("📖", ROOT_DIR / "handbook", name="undergraduate-handbook"),
     TestCase(
         "📖", ROOT_DIR / "handbook", name="graduate-handbook", env={"GRADUATE": "true"}
-- 
2.48.1.windows.1

</details>
