### PR TITLE
fix: 封面信息整体应居中

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1918,7 +1918,7 @@
 %
 % 参数如下：
 % \begin{itemize}
-%   \item \#1 |{token_list}| 为封面信息条目的名称。
+%   \item \#1 |{token_list}| 为封面信息条目的名称，含分隔符。
 %   \item \#2 |{token_list}| 为封面信息条目的内容。
 % \end{itemize}
 %
@@ -1927,7 +1927,7 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_render_cover_entry:nn #1#2 {
   \makebox[\l_@@_cover_label_max_width_dim][\l_@@_cover_label_align_tl]{
-    \tl_if_blank:VTF #1 {} {#1\l_@@_cover_delimiter_tl}
+    \tl_if_blank:VTF #1 {} {#1}
   }
   \hspace{1ex}
   \@@_dunderline:nnn{\l_@@_cover_underline_offset_dim}
@@ -1983,7 +1983,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_parse_entry}
-% 解析封面信息条目。
+% 解析封面信息条目，并添加分隔符。
 %
 % 参数如下：
 % \begin{itemize}
@@ -1999,7 +1999,7 @@
   \seq_map_inline:Nn \l_@@_tmp_right_seq {
     \seq_put_right:Nn \l_@@_tmp_left_seq {}
   }
-  \seq_put_left:Nn \l_@@_tmp_left_seq {#1}
+  \seq_put_left:Nn \l_@@_tmp_left_seq {#1\l_@@_cover_delimiter_tl}
   \seq_pop_right:NN \l_@@_tmp_left_seq \g_@@_trashcan_tl
 }
 %    \end{macrocode}
@@ -3689,7 +3689,7 @@
 %
 % 参数如下：
 % \begin{itemize}
-%   \item \#1 |{token_list}| 为封面信息条目的名称。
+%   \item \#1 |{token_list}| 为封面信息条目的名称，含分隔符。
 %   \item \#2 |{token_list}| 为封面信息条目的内容。
 % \end{itemize}
 %
@@ -3698,7 +3698,7 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_render_cover_entry:nn #1#2 {
   \makebox[\l_@@_cover_label_max_width_dim][\l_@@_cover_label_align_tl]{
-    \tl_if_blank:VTF #1 {} {#1\l_@@_cover_delimiter_tl}
+    \tl_if_blank:VTF #1 {} {#1}
   }
   \hspace{1ex}
   \@@_dunderline:nnn{\l_@@_cover_underline_offset_dim}{\l_@@_cover_underline_thickness_dim}{
@@ -3754,7 +3754,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_parse_entry}
-% 解析封面信息条目。
+% 解析封面信息条目，并添加分隔符。
 %
 % 参数如下：
 % \begin{itemize}
@@ -3770,7 +3770,7 @@
   \seq_map_inline:Nn \l_@@_tmp_right_seq {
     \seq_put_right:Nn \l_@@_tmp_left_seq {}
   }
-  \seq_put_left:Nn \l_@@_tmp_left_seq {#1}
+  \seq_put_left:Nn \l_@@_tmp_left_seq {#1\l_@@_cover_delimiter_tl}
   \seq_pop_right:NN \l_@@_tmp_left_seq \g_@@_trashcan_tl
 }
 %    \end{macrocode}

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1983,7 +1983,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_parse_entry}
-% 解析封面信息条目，并添加分隔符。
+% 解析封面信息条目，丢弃空项，并添加分隔符。
 %
 % 参数如下：
 % \begin{itemize}
@@ -1992,15 +1992,23 @@
 % \end{itemize}
 % |\\| 会被视为换行符，从而实现信息条目换行的效果。
 %
+% 结果会存储到 |\l_@@_tmp_left_seq| 和 |\l_@@_tmp_right_seq|。
+%
 %    \begin{macrocode}
 \cs_new:Npn \@@_parse_entry #1 #2 {
-  \seq_set_split:Nnx \l_@@_tmp_right_seq {\\} {#2}
   \seq_clear:N \l_@@_tmp_left_seq
-  \seq_map_inline:Nn \l_@@_tmp_right_seq {
-    \seq_put_right:Nn \l_@@_tmp_left_seq {}
+  \seq_clear:N \l_@@_tmp_right_seq
+
+  % 只处理 value 非空的项
+  \tl_set:Nn \l_tmpa_tl {#2}
+  \tl_if_empty:xTF \l_tmpa_tl {} {
+    \seq_set_split:Nnx \l_@@_tmp_right_seq {\\} {#2}
+    \seq_map_inline:Nn \l_@@_tmp_right_seq {
+      \seq_put_right:Nn \l_@@_tmp_left_seq {}
+    }
+    \seq_put_left:Nn \l_@@_tmp_left_seq {#1\l_@@_cover_delimiter_tl}
+    \seq_pop_right:NN \l_@@_tmp_left_seq \g_@@_trashcan_tl
   }
-  \seq_put_left:Nn \l_@@_tmp_left_seq {#1\l_@@_cover_delimiter_tl}
-  \seq_pop_right:NN \l_@@_tmp_left_seq \g_@@_trashcan_tl
 }
 %    \end{macrocode}
 % \end{macro}
@@ -2043,9 +2051,7 @@
       {
         \seq_pop_left:NN \l_@@_left_seq \l_@@_tmpa_tl
         \seq_pop_left:NN \l_@@_right_seq \l_@@_tmpb_tl
-        \tl_if_empty:xTF \l_@@_tmpb_tl {} {
-          \@@_render_cover_entry:nn {\l_@@_tmpa_tl} {\l_@@_tmpb_tl}
-        }
+        \@@_render_cover_entry:nn {\l_@@_tmpa_tl} {\l_@@_tmpb_tl}
       }
   \group_end:
 }
@@ -3754,7 +3760,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_parse_entry}
-% 解析封面信息条目，并添加分隔符。
+% 解析封面信息条目，丢弃空项，并添加分隔符。
 %
 % 参数如下：
 % \begin{itemize}
@@ -3763,15 +3769,23 @@
 % \end{itemize}
 % |\\| 会被视为换行符，从而实现信息条目换行的效果。
 %
+% 结果会存储到 |\l_@@_tmp_left_seq| 和 |\l_@@_tmp_right_seq|。
+%
 %    \begin{macrocode}
 \cs_new:Npn \@@_parse_entry #1 #2 {
-  \seq_set_split:Nnx \l_@@_tmp_right_seq {\\} {#2}
   \seq_clear:N \l_@@_tmp_left_seq
-  \seq_map_inline:Nn \l_@@_tmp_right_seq {
-    \seq_put_right:Nn \l_@@_tmp_left_seq {}
+  \seq_clear:N \l_@@_tmp_right_seq
+
+  % 只处理 value 非空的项
+  \tl_set:Nn \l_tmpa_tl {#2}
+  \tl_if_empty:xTF \l_tmpa_tl {} {
+    \seq_set_split:Nnx \l_@@_tmp_right_seq {\\} {#2}
+    \seq_map_inline:Nn \l_@@_tmp_right_seq {
+      \seq_put_right:Nn \l_@@_tmp_left_seq {}
+    }
+    \seq_put_left:Nn \l_@@_tmp_left_seq {#1\l_@@_cover_delimiter_tl}
+    \seq_pop_right:NN \l_@@_tmp_left_seq \g_@@_trashcan_tl
   }
-  \seq_put_left:Nn \l_@@_tmp_left_seq {#1\l_@@_cover_delimiter_tl}
-  \seq_pop_right:NN \l_@@_tmp_left_seq \g_@@_trashcan_tl
 }
 %    \end{macrocode}
 % \end{macro}
@@ -3814,9 +3828,7 @@
       {
         \seq_pop_left:NN \l_@@_left_seq \l_@@_tmpa_tl
         \seq_pop_left:NN \l_@@_right_seq \l_@@_tmpb_tl
-        \tl_if_empty:xTF \l_@@_tmpb_tl {} {
-          \@@_render_cover_entry:nn {\l_@@_tmpa_tl} {\l_@@_tmpb_tl}
-        }
+        \@@_render_cover_entry:nn {\l_@@_tmpa_tl} {\l_@@_tmpb_tl}
       }
   \group_end:
 }


### PR DESCRIPTION
Fixes #613

## 测试

```latex
% !TeX program = xelatex

% \documentclass[type=bachelor]{bithesis}
\documentclass[type=master]{bithesis}
\BITSetup{
  info = {
    title = 国国国口口口口口口口口国国国,
    author = 张三,
    school = 材料学院,
    supervisor = 李四教授,
    chairman = 王五教授,
    industrialMentor = 李五教授,
    degree = { 材料与化工 \\ 博士 },
    major = 材料工程,
  },
}

\begin{document}

% \MakeCover
\MakeTitle

\end{document}
```

<details>
<summary>截图</summary>

![图片](https://github.com/user-attachments/assets/0867a40e-61f9-4eb6-97f8-8b104fb4a9af)
![图片](https://github.com/user-attachments/assets/d449b059-244f-46c8-bb3e-79e3e536244d)

</details>

## 调试时新发现的问题（现已解决）

1584719 让本科模板又偏右了……

<details>
<summary>截图</summary>

![图片](https://github.com/user-attachments/assets/1afc3e5b-0643-4c6d-bb31-e090293d1d41)

</details>

原因在于本科有六字的`校外指导教师`，通常不显示，但仍计入了`\@@_get_max_text_width:NN`。
https://github.com/BITNP/BIThesis/blob/3c5e39729497701ec52d70691058bffe99cd02d6/bithesis.dtx#L490
https://github.com/BITNP/BIThesis/blob/3c5e39729497701ec52d70691058bffe99cd02d6/bithesis.dtx#L2540

```latex
\clist_set:Nn \l_@@_input_clist {
  {项目} {内容内容内容},
  {不存在不存在} {},
}

\@@_render_cover_entry:n \l_@@_input_clist
```

<details>
<summary>截图</summary>

![图片](https://github.com/user-attachments/assets/76a1ea50-5d5c-42e0-9d7c-56efd2ab2266)

</details>

## 相对 https://github.com/BITNP/BIThesis/releases/tag/v3.8.3 回归测试

<details>
<summary>截图</summary>

![图片](https://github.com/user-attachments/assets/46ba891c-6148-4eb8-9d79-bc1ea61a089a)
![图片](https://github.com/user-attachments/assets/1623310a-4766-4210-9208-ca924ff1a176)
![图片](https://github.com/user-attachments/assets/7f4d3a37-8b5e-44b3-ae48-2dd204ab6dd6)
![图片](https://github.com/user-attachments/assets/4c8787ca-b89c-479f-a2f1-be13621cd01d)
![图片](https://github.com/user-attachments/assets/b8bed66b-04f6-4b57-8354-7597737cf630)

</details>

无意外变化。