### PR TITLE
fix(GT): 封皮、题名页标题的行距不应过小

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2069,7 +2069,7 @@
     }
     \centering
     \vspace*{65mm}
-    {\heiti\zihao{-2} \l_@@_value_title_tl}
+    {\heiti\zihao{-2} \l_@@_value_title_tl \par}
     \vskip 60mm
     {
       % 渲染信息。
@@ -2193,7 +2193,7 @@
 
       \vskip \stretch{1}
 
-         {\heiti\zihao{-2} \l_@@_value_title_tl}
+      {\heiti\zihao{-2} \l_@@_value_title_tl \par}
 
       \vskip \stretch{1}
 
@@ -2255,6 +2255,7 @@
     {
       \zihao{-2}
       \textbf{\l_@@_value_title_en_tl}
+      \par
     }
 
     \vskip \stretch{1}


### PR DESCRIPTION
Resolves #617

“行距的改变直到文字分段时才生效”，之前缺`\par`，没设置上。

![图片](https://github.com/user-attachments/assets/45445107-ba81-4baa-8a82-03ba5eaa0271)

目前行距还是比 Word 模板略小；还需要再调大吗？
