### PR TITLE
 feat: 支持隐去PDF书签，支持修改结论标题

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test: copy FORCE_MAKE
 		python scripts/test.py
 
 .PHONY: regression-test
-regression-test: cls
+regression-test: copy
 	uv run scripts/regression_test.py $(args)
 
 .PHONY: copy-only

--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1079,7 +1079,7 @@ windowsSimSunFakeBold = (*(false)|true*)
 \end{bitsyntax}
 
 在 Windows 平台下，由于中易宋体没有粗体字重；
-ctex 会默认选择较为美观的楷体代替粗体宋体。
+ctex 会默认选择较为美观的黑体代替粗体宋体。
 开启此选项可以开启伪粗体的渲染，从而渲染宋体伪粗体。
 
 \end{function}
@@ -1565,7 +1565,7 @@ substituteSymbol = (*(*)|\marg{字符串}*),
 
 \subsection{封面及基本信息}
 
-\begin{function}[updated=2025-03-31]{\MakeCover}
+\begin{function}[updated=2025-04-15]{\MakeCover}
 
   \textit{封面内容会根据模板选项（具体参见节
     \ref{sec:template-options}）中\meta{type=xxx}的值而变化。}
@@ -1575,7 +1575,7 @@ substituteSymbol = (*(*)|\marg{字符串}*),
   绘制封面。
 
   在默认配置下，封面中的下划线会自动计算最大宽度。
-  此时，如果用户需要换行，可以通过「\\」控制换行。
+  此时，如果用户需要换行，可以通过「|\\|」控制换行。
 
   当关闭自动计算下划线宽度后，
   可以通过
@@ -1587,6 +1587,8 @@ substituteSymbol = (*(*)|\marg{字符串}*),
   \meta{valueMaxWidth=xxx}
 
   来指定下划线的宽度。一般情况下，我们不建议您这样做。
+
+  默认加入PDF书签。如需隐去，可设置 |\MakeCover[bookmarked = false]|。
 \end{function}
 
 \begin{function}{\SecretInfo{}[]}
@@ -1601,19 +1603,25 @@ substituteSymbol = (*(*)|\marg{字符串}*),
   否则，将使用第二个参数替换内容。
 \end{function}
 
-\begin{function}[updated=2025-03-31]{\MakePaperBack}
+\begin{function}[updated=2025-04-15]{\MakePaperBack}
 
-  绘制书脊。
+  绘制书脊，用于\BIThesisTemplates{GT}。
+
+  默认加入PDF书签。如需隐去，可设置 |\MakePaperBack[bookmarked = false]|。
 \end{function}
 
-\begin{function}{\MakeTitle}
+\begin{function}[updated=2025-04-15]{\MakeTitle}
 
-  绘制中英文信息页。
+  绘制中英文信息页，用于\BIThesisTemplates{GT}。
+
+  默认两页均加入PDF书签。如需共同隐去，可设置 |\MakeTitle[bookmarked = false]|。
 \end{function}
 
-\begin{function}{\MakeOriginality}
+\begin{function}[updated=2025-04-15]{\MakeOriginality}
 
-  绘制中英文信息页。
+  绘制原创性声明、关于使用授权的声明（本科）或研究成果声明、关于学位论文使用权的说明（硕博）。
+
+  默认加入PDF书签。如需隐去，可设置 |\MakeOriginality[bookmarked = false]|。
 \end{function}
 
 \subsection{前置部分}

--- a/bithesis-doc.tex
+++ b/bithesis-doc.tex
@@ -1766,12 +1766,21 @@ addTOC = (*<(true)|false>*)
 
 \end{function}
 
-\begin{function}[label=env.conclusion]{conclusion}
+\begin{function}[updated=2025-04-15, label=env.conclusion]{conclusion}
 \begin{bitsyntax}[emph={[1]conclusion}]
 \begin{conclusion}
    (*\meta{结论}*)
 \end{conclusion}
 \end{bitsyntax}
+
+  标题默认按论文类型自动设置。如需更改，可如下设置 |title|。
+
+\begin{latex}[emph={[1]conclusion}]
+\begin{conclusion}[title = 结论与 $\lim_{t \to +\infty}$]
+  结论作为学位论文正文的最后部分单独排写，但不加章号。
+\end{conclusion}
+\end{latex}
+
 \end{function}
 
 \begin{function}[label=env.bibprint]{bibprint}

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -546,14 +546,16 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \subsubsection{l3keys 接口键值对定义}
+% \subsubsection{BITSetup l3keys 接口键值对定义}
 %
+% \begin{macro}{\c_@@_auto_tl}
 % 定义 |\c_@@_auto_tl|
 % 选项设为它时，表示智能默认值，稍后由 |\@@_resolve_auto_values:| 根据其它信息自动填充。
 % 参考 https://typst.app/docs/reference/foundations/auto/ 的设计。
 %    \begin{macrocode}
 \tl_const:Nn \c_@@_auto_tl { BIThesis-auto-magic }
 %    \end{macrocode}
+% \end{macro}
 %
 % 定义 |bithesis| 键值对类。
 %    \begin{macrocode}
@@ -927,6 +929,8 @@
 }
 %    \end{macrocode}
 %
+% \subsubsection{内部 l3keys 接口键值对定义}
+%
 % 除了 |\BITSetup|，有些用户接口也是键值对，在此通过 |bithesis-internal| 实现。
 % 约定它只用于内部解析用户命令传入的参数，不直接面向最终作者，而且每个用户命令都不记忆之前设置的值。
 % 此处只定义数据结构，默认值等逻辑由各命令自行处理。
@@ -941,11 +945,14 @@
 }
 %    \end{macrocode}
 %
+% \subsubsection{BITSetup l3keys 接口键值对预处理}
+%
 % 在宏加载时，处理 |bithesis/option| 中的值。使得 |bithesis|
 % 宏包的模板选项可以在宏加载时生效。
 %    \begin{macrocode}
 \ProcessKeysOptions { bithesis / option }
 %    \end{macrocode}
+%
 % 确定 |bithesis/option| 中的 |\g_@@_thesis_type_int| 后，根据论文类型自动覆盖某些选项的默认值。
 %    \begin{macrocode}
 \@@_if_graduate:TF {
@@ -955,8 +962,7 @@
 }
 %    \end{macrocode}
 %
-% \subsubsection{l3keys 键值对预处理}
-%
+% \begin{macro}{\@@_resolve_auto_values:}
 % 计算 auto 并替换为标准的值
 %    \begin{macrocode}
 \cs_new:Npn \@@_resolve_auto_values: {
@@ -980,6 +986,7 @@
   }
 }
 %    \end{macrocode}
+% \end{macro}
 %
 % \subsubsection{应用模板选项}
 %

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -945,6 +945,15 @@
 }
 %    \end{macrocode}
 %
+% 定义 |bithesis-internal / conclusion|，用于设置 |conclusion| 环境。
+%    \begin{macrocode}
+\keys_define:nn { bithesis-internal / conclusion }
+{
+  title .tl_set:N = \l_@@_internal__conclusion__title_tl,
+}
+%    \end{macrocode}
+%
+%
 % \subsubsection{BITSetup l3keys 接口键值对预处理}
 %
 % 在宏加载时，处理 |bithesis/option| 中的值。使得 |bithesis|
@@ -3132,17 +3141,25 @@
 % \begin{environment}{conclusion}
 % 生成结论。需要放在 \cs{macrocode} 之后。
 %    \begin{macrocode}
-\NewDocumentEnvironment {conclusion} {}
+\NewDocumentEnvironment {conclusion} { O{} }
   {
+    \group_begin:
+    % 解析传入参数
+    \keys_set:nn { bithesis-internal / conclusion } {
+      title = \@@_if_thesis_english:TF {
+        \c_@@_label_conclusion_en_tl
+      } {
+        \c_@@_label_conclusion_tl
+      },
+    }
+    \keys_set:nn { bithesis-internal / conclusion } { #1 }
+
     \ctexset{
       section/number = \arabic{section}
     }
 
-    \@@_if_thesis_english:TF {
-      \chapter{\c_@@_label_conclusion_en_tl}
-    } {
-      \chapter{\c_@@_label_conclusion_tl}
-    }
+    \chapter{\l_@@_internal__conclusion__title_tl}
+    \group_end:
   }
   {}
 %    \end{macrocode}

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -926,6 +926,21 @@
   minbibnames .initial:n = {10},
 }
 %    \end{macrocode}
+%
+% 除了 |\BITSetup|，有些用户接口也是键值对，在此通过 |bithesis-internal| 实现。
+% 约定它只用于内部解析用户命令传入的参数，不直接面向最终作者，而且每个用户命令都不记忆之前设置的值。
+% 此处只定义数据结构，默认值等逻辑由各命令自行处理。
+%
+% 定义 |bithesis-internal / pre-frontmatter|，用于设置 |\frontmatter| 之前的 |\MakeCover|、|\MakeTitle| 等。
+% 目前这些部分的接口相同，故共用 |pre-frontmatter|。
+%    \begin{macrocode}
+\keys_define:nn { bithesis-internal / pre-frontmatter }
+{
+  % 是否将标题加入PDF书签
+  bookmarked .bool_set:N = \l_@@_internal__pre_frontmatter__bookmarked_bool,
+}
+%    \end{macrocode}
+%
 % 在宏加载时，处理 |bithesis/option| 中的值。使得 |bithesis|
 % 宏包的模板选项可以在宏加载时生效。
 %    \begin{macrocode}
@@ -2060,7 +2075,9 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_make_graduate_cover: {
   \cleardoublepage
-  \currentpdfbookmark{封面}{frontmatter:cover1}
+  \bool_if:NT \l_@@_internal__pre_frontmatter__bookmarked_bool {
+    \currentpdfbookmark{封面}{pre-frontmatter:cover}
+  }
   \begin{titlepage}
     {
       \heiti\zihao{5}
@@ -2104,7 +2121,9 @@
   }
 \cs_new:Npn \@@_make_paper_back: {
   \cleardoublepage
-  \currentpdfbookmark{书脊}{frontmatter:paperback}
+  \bool_if:NT \l_@@_internal__pre_frontmatter__bookmarked_bool {
+    \currentpdfbookmark{书脊}{pre-frontmatter:paperback}
+  }
   \begin{titlepage}
     \centering
     % 实现竖排——将水平宽度设得很窄，让文字自动换行，并改小行距
@@ -2144,7 +2163,9 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_make_chinese_title_page: {
   \cleardoublepage
-  \currentpdfbookmark{中文题名页}{frontmatter:titlepage}
+  \bool_if:NT \l_@@_internal__pre_frontmatter__bookmarked_bool {
+    \currentpdfbookmark{中文题名页}{pre-frontmatter:titlepage-zh}
+  }
   \begin{titlepage}
       \begin{minipage}[t]{0.48\textwidth}
         % 密级、分类号
@@ -2249,7 +2270,9 @@
 % 制作英文封面页。
 %    \begin{macrocode}
 \cs_new:Npn \@@_make_english_title_page: {
-  \currentpdfbookmark{英文题名页}{frontmatter:titlepageen}
+  \bool_if:NT \l_@@_internal__pre_frontmatter__bookmarked_bool {
+    \currentpdfbookmark{英文题名页}{pre-frontmatter:titlepage-en}
+  }
   \begin{titlepage}
     \begin{center}
 
@@ -2340,7 +2363,9 @@
             titleformat = {\heiti\zihao{-2}},
           }
         }
-        \currentpdfbookmark{\c_@@_graduate_label_originality_tl}{frontmatter:originality}
+        \bool_if:NT \l_@@_internal__pre_frontmatter__bookmarked_bool {
+          \currentpdfbookmark{\c_@@_graduate_label_originality_tl}{pre-frontmatter:originality}
+        }
         \chapter*{
           \c_@@_graduate_label_originality_tl
         }
@@ -2365,7 +2390,9 @@
             titleformat = {\heiti\zihao{-2}},
           }
         }
-        \currentpdfbookmark{\c_@@_graduate_label_authorization_tl}{frontmatter:originality1}
+        \bool_if:NT \l_@@_internal__pre_frontmatter__bookmarked_bool {
+          \currentpdfbookmark{\c_@@_graduate_label_authorization_tl}{pre-frontmatter:originality-authorization}
+        }
         \chapter*{
           \c_@@_graduate_label_authorization_tl
         }
@@ -2462,10 +2489,14 @@
 % \begin{macro}{\MakeCover}
 % 制作封面。
 %    \begin{macrocode}
-\DeclareDocumentCommand \MakeCover {}
+\DeclareDocumentCommand \MakeCover { O{} }
   {
     \begin{blindPeerReview}[\l_@@_cover_hide_cover_in_peer_review_bool]
     \group_begin:
+
+    % 解析传入参数
+    \keys_set:nn { bithesis-internal / pre-frontmatter } { bookmarked = true }
+    \keys_set:nn { bithesis-internal / pre-frontmatter } { #1 }
 
     % 封面使用的 thesis-type 可能与整体不同。
     \int_new:N \l_@@_thesis_type_int
@@ -2479,7 +2510,9 @@
     {
       {1}
       {
-        \currentpdfbookmark{封面}{frontmatter:cover}
+        \bool_if:NT \l_@@_internal__pre_frontmatter__bookmarked_bool {
+          \currentpdfbookmark{封面}{pre-frontmatter:cover}
+        }
         \begin{titlepage}
           \vspace*{16mm}
 
@@ -2567,6 +2600,9 @@
       }
       {2}
       {
+        \bool_if:NT \l_@@_internal__pre_frontmatter__bookmarked_bool {
+          \currentpdfbookmark{封面}{pre-frontmatter:cover}
+        }
         \begin{titlepage}
           \centering
 
@@ -2653,6 +2689,9 @@
         \end{titlepage}
       }
       {3} {
+        \bool_if:NT \l_@@_internal__pre_frontmatter__bookmarked_bool {
+          \currentpdfbookmark{Cover}{pre-frontmatter:cover}
+        }
         \begin{titlepage}
           \vspace*{16mm}
 
@@ -2738,15 +2777,21 @@
 % \begin{macro}{\MakeOriginality}
 % 原创性声明。
 %    \begin{macrocode}
-\NewDocumentCommand \MakeOriginality {}
+\NewDocumentCommand \MakeOriginality { O{} }
   {
     \group_begin:
+    % 解析传入参数
+    \keys_set:nn { bithesis-internal / pre-frontmatter } { bookmarked = true }
+    \keys_set:nn { bithesis-internal / pre-frontmatter } { #1 }
+
     \begin{blindPeerReview}[\l_@@_cover_hide_cover_in_peer_review_bool]
       \int_case:nn {\g_@@_thesis_type_int}
       {
         {1}
         {
-          \currentpdfbookmark{声明}{frontmatter:originality}
+          \bool_if:NT \l_@@_internal__pre_frontmatter__bookmarked_bool {
+            \currentpdfbookmark{声明}{pre-frontmatter:originality}
+          }
           \pagestyle{BIThesis}
           \pagenumbering{gobble}
 
@@ -2794,7 +2839,9 @@
           \newpage
         }
         {3} {
-          \currentpdfbookmark{Statements}{frontmatter:originality}
+          \bool_if:NT \l_@@_internal__pre_frontmatter__bookmarked_bool {
+            \currentpdfbookmark{Statements}{pre-frontmatter:originality}
+          }
           \pagestyle{BIThesis}
           \pagenumbering{gobble}
 
@@ -2849,9 +2896,9 @@
 % \end{macro}
 %
 % \begin{macro}{\MakePaperBack}
-% 生成书脊。
+% 生成书脊。（研究生）
 %    \begin{macrocode}
-\NewDocumentCommand \MakePaperBack {}
+\NewDocumentCommand \MakePaperBack { O{} }
   {
     % 上下各留出规定的边距，到下一页再恢复。
     % 若标题超长，自然会向上下溢出。
@@ -2864,7 +2911,14 @@
       vmargin = 5cm,
     }
     \begin{blindPeerReview}[\l_@@_cover_hide_cover_in_peer_review_bool]
+      \group_begin:
+      % 解析传入参数
+      \keys_set:nn { bithesis-internal / pre-frontmatter } { bookmarked = true }
+      \keys_set:nn { bithesis-internal / pre-frontmatter } { #1 }
+
       \@@_make_paper_back:
+
+      \group_end:
     \end{blindPeerReview}
     \restoregeometry
   }
@@ -2874,11 +2928,18 @@
 % \begin{macro}{\MakeTitle}
 % 生成标题页。（研究生）
 %    \begin{macrocode}
-\NewDocumentCommand \MakeTitle {}
+\NewDocumentCommand \MakeTitle { O{} }
   {
     \begin{blindPeerReview}[\l_@@_cover_hide_cover_in_peer_review_bool]
+      \group_begin:
+      % 解析传入参数
+      \keys_set:nn { bithesis-internal / pre-frontmatter } { bookmarked = true }
+      \keys_set:nn { bithesis-internal / pre-frontmatter } { #1 }
+
       \@@_make_chinese_title_page:
       \@@_make_english_title_page:
+
+      \group_end:
     \end{blindPeerReview}
   }
 %    \end{macrocode}


### PR DESCRIPTION
- **feat: 支持在PDF书签中隐去封面、书脊、题名页、声明，如`\MakeCover[bookmarked = false]`**
- **docs: 改进 DocStrip 里的文档**
- **feat: 支持用`title`修改`conclusion`环境内的标题**

Resolves #623

这次的选项只控制局部，键值对直接挂了命令上，没有挂到`\BITSetup`。

设计参考了`texdoc interface3`。

<details>
<summary>interface3.pdf 节选</summary>

```latex
\MyModuleMacro[
  key-one = value one,
  key-two = value two
]{argument}
```

```latex
\DeclareDocumentCommand \MyModuleMacro { o m }
{
  \group_begin:
  \keys_set:nn { mymodule } { #1 }
  % Main code for \MyModuleMacro
  \group_end:
}
```

</details>

`make regression-test args='--against main-c97d797'`没有区别。

## MWE

```latex
% !TeX program = xelatex

\documentclass[type=bachelor]{bithesis}

\begin{document}

\MakeCover[bookmarked = false]
\MakePaperBack[bookmarked = false]
\MakeTitle  % 默认 bookmarked = true
\MakeOriginality[bookmarked = false]

\frontmatter

\mainmatter

\backmatter

\begin{conclusion}
  结论部分的标题默认按论文类型自动设置。
\end{conclusion}

\begin{conclusion}[title = 结论与 $\lim_{t \to +\infty}$]
  如需更改，可设置 title。
\end{conclusion}

\end{document}
```

![图片](https://github.com/user-attachments/assets/9d106334-492d-4995-9681-a70bb0338562)

