### PR TITLE
feat: 给摘要页竖直间距增加弹性，允许写更多内容

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -3074,11 +3074,12 @@
       }
     }
 
-    % 微调硕博模板标题上下的间距
-    \@@_if_graduate:T { \ctexset{ chapter = {
-      beforeskip = 13bp,
-      afterskip = 24bp,
-    } } }
+    % 摘要对页数很敏感，标题上下间距应有弹性；其中硕博模板的基础长度参考 Word 实作微调过。
+    \ctexset{ chapter = {
+      % 最短均为 8bp
+      beforeskip = \@@_if_graduate:TF {13bp minus 5bp} {8bp},
+      afterskip = \@@_if_graduate:TF {24bp minus 16bp} {32bp minus 24bp},
+    } }
 
     {
       \@@_same_page:
@@ -3094,7 +3095,8 @@
   }
   {
     \par
-    \vspace{4ex}
+    % 摘要对页数很敏感，关键词上方间距应有弹性
+    \vspace{4ex minus 4ex}
     \noindent
     \@@_if_graduate:TF {
       % 研究生模板中，“关键词”宋体小四加粗
@@ -3127,7 +3129,8 @@
           \l_@@_value_title_en_tl\\
         }
       \end{spacing}
-      \vspace*{10mm}
+      % 最短缩到与中文摘要相同
+      \vspace*{10mm minus 8mm}
     }
 
     \ctexset{
@@ -3144,11 +3147,12 @@
       }
     }
 
-    % 微调硕博模板标题上下的间距
-    \@@_if_graduate:T { \ctexset{ chapter = {
-      beforeskip = 19bp,
-      afterskip = 35bp,
-    } } }
+    % 摘要对页数很敏感，标题上下间距应有弹性；其中硕博模板的基础长度参考 Word 实作微调过。
+    \ctexset{ chapter = {
+      % 最短均为 8bp
+      beforeskip = \@@_if_graduate:TF {19bp minus 11bp} {8bp},
+      afterskip = \@@_if_graduate:TF {35bp minus 27bp} {32bp minus 24bp},
+    } }
 
     {
       \@@_same_page:
@@ -3161,7 +3165,8 @@
     }
   }
   {
-    \par\vspace{3ex}\noindent
+    % 摘要对页数很敏感，关键词上方间距应有弹性
+    \par\vspace{3ex minus 3ex}\noindent
     \@@_if_graduate:TF {
       % Times New Roman小四号字，行距22磅
       % “Key Words”


### PR DESCRIPTION
群里有人遇到关键词被挤到下一页，只好在`abstract`环境内`\vspace{-4ex}`。

## 最小例子

<details><summary>测试用例</summary>

```latex
\documentclass[type=bachelor]{bithesis}

\usepackage{lipsum}
\usepackage{zhlipsum}

\begin{document}
\frontmatter

\begin{abstract}
  \zhlipsum[1-2]
  当我沉默著的时候，我觉得充实；我将开口，同时感到空虚。
\end{abstract}

\begin{abstractEn}
  \lipsum*[1-3]

  Do you here the people sing?
  Singing a song of angry men?
\end{abstractEn}

\end{document}
```

```latex
\documentclass[type=master]{bithesis}

\usepackage{lipsum}
\usepackage{zhlipsum}

\begin{document}
\frontmatter

\begin{abstract}
  \zhlipsum[1-2]

  当我沉默著的时候，我觉得充实；我将开口，同时感到空虚。

  过去的生命已经死亡。我对于这死亡有大欢喜，因为我借此知道它曾经存活。死亡的生命已经朽腐。我对于这朽腐有大欢喜，因为我借此知道它还非空虚。

  生命的泥委弃在地面上，不生乔木，只生野草，这是我的罪过。
\end{abstract}

\begin{abstractEn}
  \lipsum*[1-3]

  Do you here the people sing?
  Singing a song of angry men?

  It is the music of a people
  Who will not be slaves again!

  When the beating of your heart
  Echoes the beating of the drums

  There is a life about to start
  When tomorrow comes.
\end{abstractEn}

\end{document}
```

</details> 

### 此PR

![图片](https://github.com/user-attachments/assets/b6d2e165-b0ff-4731-a963-888953f3fb6d)

![图片](https://github.com/user-attachments/assets/1d342f81-487a-4990-88f5-5ac2891b86d3)

### v3.8.5-alpha-2

![图片](https://github.com/user-attachments/assets/ac869673-c065-4b4d-99aa-2a8f73094a65)
![图片](https://github.com/user-attachments/assets/12e26081-2587-4dd9-a274-4048efb87450)


## 回归测试 against v3.8.4

完全没有区别，因为模板包里的例子较短，用基础长度就能排下，不会触发 minus。
