### PR TITLE
fix: 限制盲审模式题名页`***`长度，以防行溢出

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -213,6 +213,19 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\@@_warning_footer:n}
+% 用 l3msg 创建警告时，需后缀的内容。
+% 参数建议为 ⟨message⟩，即 |\msg_new:nnn| 系列函数的第二个参数。
+%
+% 之所以设置此函数，是因为 VS Code 插件 LaTeX Workshop 无法识别随意放置的 |\msg_line_context:|，只好专门适配。
+% https://github.com/James-Yu/LaTeX-Workshop/blob/c62e327b8233e20d61814bfda305811bea1ae83f/src/parse/parser/latexlog.ts#L17
+%    \begin{macrocode}
+\cs_new:Npn \@@_warning_footer:n #1 {
+    —The~“#1”\\warning~on~input~line~\msg_line_number:.
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}{\@@_same_page:}
 % 取消换页。
 %    \begin{macrocode}
@@ -2023,6 +2036,15 @@
 }
 %    \end{macrocode}
 % \end{macro}
+
+% \begin{macro}{|@@_cover_entry_rendered_width:}
+% 预估 |\@@_render_cover_entry:nn| 会占用的宽度，可用于判断行是否会溢出
+%    \begin{macrocode}
+\cs_new:Nn \@@_cover_entry_rendered_width: {
+  \l_@@_cover_label_max_width_dim + 1ex + \l_@@_cover_value_max_width_dim
+}
+%    \end{macrocode}
+% \end{macro}
 %
 % \begin{macro}{|@@_get_text_width:Nn,\@@_get_text_width:NV}
 % 计算 \#2 所占用的宽度，将结果存储在 \#1 中。
@@ -2103,6 +2125,12 @@
 % \begin{macro}{\@@_render_cover_entry}
 % 渲染封面信息项。此函数为主函数。
 %    \begin{macrocode}
+\msg_new:nnn { bithesis } { render-cover-entry/overfull-hbox }
+  {
+    One~or~more~cover~entries~are~too~wide,~which~may~result~in~poor~layout.\\
+    To~fix~it,~please~split~long~entries~into~multiple~lines~by~inserting~“\c_backslash_str\c_backslash_str”.\\
+    \@@_warning_footer:n { render-cover-entry/overfull-hbox }
+  }
 \cs_new:Npn \@@_render_cover_entry:N #1 {
   % 左边是标签，右边是值。
   % 形如：
@@ -2129,6 +2157,9 @@
     \@@_get_max_text_width:NN \l_@@_cover_value_max_width_dim \l_@@_right_seq
     % 在 value 两边加上空白，避免文本太靠边。
     \dim_add:Nn \l_@@_cover_value_max_width_dim { \l_@@_cover_auto_width_padding_dim * 2 }
+  }
+  \dim_compare:nNnT { \linewidth } < { \@@_cover_entry_rendered_width: } {
+    \msg_warning:nn {bithesis} {render-cover-entry/overfull-hbox}
   }
 
 
@@ -2188,11 +2219,11 @@
 % \begin{macro}{\@@_make_paper_back:}
 % 制作书脊。
 %    \begin{macrocode}
-% TODO: 使用统一方式警告
 \msg_new:nnn { bithesis } { paper-back/missing-degree-type-icon-file }
   {
     Failed~to~find~the~file~for~degree~type~in~the~paper~back:~#1.\\
-    Please~download~from~https://github.com/BITNP/BIThesis/blob/main/templates/graduate-thesis/ #1.
+    Please~download~from~https://github.com/BITNP/BIThesis/blob/main/templates/graduate-thesis/ #1.\\
+    \@@_warning_footer:n { paper-back/missing-degree-type-icon-file }
   }
 \cs_new:Npn \@@_make_paper_back: {
   \cleardoublepage
@@ -2757,8 +2788,7 @@
               {\c_@@_label_author_tl} {\@@_secret_info_fixed:Nn \l_@@_value_author_tl {3}},
               {\c_@@_label_student_id_tl} {\@@_secret_info:N \l_@@_value_student_id_tl},
               {\c_@@_label_supervisor_tl} {\@@_secret_info_fixed:Nn \l_@@_value_supervisor_tl {5}},
-              % co-supervisor 并非所有人都有，由最终作者自行处理
-              {\c_@@_label_co_supervisor_tl} {\@@_secret_info:N \l_@@_value_external_supervisor_tl},
+              {\c_@@_label_co_supervisor_tl} {\@@_secret_info_fixed:Nn \l_@@_value_external_supervisor_tl {5}},
             }
 
             \@@_render_cover_entry:N \l_@@_input_clist

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -136,6 +136,7 @@
 %
 % \begin{macro}[added=2023-05-06,updated=2023-07-04]{\@@_secret_info:nn,\@@_secret_info:N,\@@_secret_info:n}
 % 普通模式下显示参数一，盲审模式下显示参数二。
+% 无参数二时，替换为等量 |\g_@@_const_substitute_symbol_tl|，换行也会被替换。
 % \begin{macrocode}
 \cs_new:Npn \@@_hide:n #1 {
   \g_@@_const_substitute_symbol_tl
@@ -156,7 +157,22 @@
   \@@_secret_info:nn {#1} {\tl_map_function:NN {#1} \@@_hide:n }
 }
 % \end{macrocode}
+% \end{macro}
 %
+% \begin{macro}[added=2025-04-30]{\@@_secret_info_fixed:Nn}
+% 普通模式下显示参数一，盲审模式下显示参数二个数的 |\g_@@_const_substitute_symbol_tl|。
+% 例外：若参数一为空，也输出空。这样允许 |\@@_render_cover_entry:nn| 隐藏此项。
+% 为了实现例外，参数一必须是 N 而非 n，不然难以检测是否真正为空。
+%
+%    \begin{macrocode}
+\cs_new:Npn \@@_secret_info_fixed:Nn #1 #2 {
+  \tl_if_blank:VF #1 {
+    \@@_secret_info:nn {#1} {
+      \prg_replicate:nn {#2} {\g_@@_const_substitute_symbol_tl}
+    }
+  }
+}
+%    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}[added=2023-03-16, updated=2025-04-04]{\@@_get_const:n} 获取标题、章节、表格、图形等的常量名称。
@@ -2152,7 +2168,7 @@
     {
       % 渲染信息。
       \clist_set:Nn \l_@@_input_clist {
-        {姓名：} {\@@_secret_info:nn{\l_@@_value_author_tl}{\g_@@_const_substitute_symbol_tl\g_@@_const_substitute_symbol_tl\g_@@_const_substitute_symbol_tl}},
+        {姓名：} {\@@_secret_info_fixed:Nn \l_@@_value_author_tl {3}},
         {学号：} {\@@_secret_info:N \l_@@_value_student_id_tl},
         {学院：} {\l_@@_value_school_tl},
       }
@@ -2302,12 +2318,13 @@
         }
 
         % 渲染信息。
+        % 此处必须限制盲审模式替换符号数量，不然会泄露信息，还可能导致行溢出
         \clist_set:Nn \l_@@_input_clist {
-            {\c_@@_graduate_label_author_tl} {\@@_secret_info:nn{\l_@@_value_author_tl}{\g_@@_const_substitute_symbol_tl\g_@@_const_substitute_symbol_tl\g_@@_const_substitute_symbol_tl}},
+            {\c_@@_graduate_label_author_tl} {\@@_secret_info_fixed:Nn \l_@@_value_author_tl {3}},
             {\c_@@_graduate_label_school_tl} {\l_@@_value_school_tl},
-            {\c_@@_graduate_label_supervisor_tl} {\@@_secret_info:N{\l_@@_value_supervisor_tl}},
-            {\c_@@_graduate_label_industrial_mentor_tl} {\@@_secret_info:N{\l_@@_value_industrial_mentor_tl}},
-            {\c_@@_graduate_label_chairman_tl} {\@@_secret_info:N{\l_@@_value_chairman_tl}},
+            {\c_@@_graduate_label_supervisor_tl} {\@@_secret_info_fixed:Nn \l_@@_value_supervisor_tl {5}},
+            {\c_@@_graduate_label_industrial_mentor_tl} {\@@_secret_info_fixed:Nn \l_@@_value_industrial_mentor_tl {5}},
+            {\c_@@_graduate_label_chairman_tl} {\@@_secret_info_fixed:Nn \l_@@_value_chairman_tl {5}},
             {\g_@@_const_info_degree_tl} {\l_@@_value_degree_tl},
             {\g_@@_const_info_major_tl} {\l_@@_value_major_tl},
             {\c_@@_graduate_label_institute_tl} {\l_@@_value_institute_tl},
@@ -2364,12 +2381,13 @@
       }
 
       % 渲染信息。
+      % 此处必须限制盲审模式替换符号数量，不然会泄露信息，还可能导致行溢出
       \clist_set:Nn \l_@@_input_clist {
-          {\c_@@_graduate_label_author_en_tl} {\@@_secret_info:N{\l_@@_value_author_en_tl}},
+          {\c_@@_graduate_label_author_en_tl} {\@@_secret_info_fixed:Nn \l_@@_value_author_en_tl {9}},
           {\c_@@_graduate_label_school_en_tl} {\l_@@_value_school_en_tl},
-          {\c_@@_graduate_label_supervisor_en_tl} {\@@_secret_info:N{\l_@@_value_supervisor_en_tl}},
-          {\c_@@_graduate_label_industrial_mentor_en_tl} {\@@_secret_info:N{\l_@@_value_industrial_mentor_en_tl}},
-          {\c_@@_graduate_label_chairman_en_tl} {\@@_secret_info:N{\l_@@_value_chairman_en_tl}},
+          {\c_@@_graduate_label_supervisor_en_tl} {\@@_secret_info_fixed:Nn \l_@@_value_supervisor_en_tl {12}},
+          {\c_@@_graduate_label_industrial_mentor_en_tl} {\@@_secret_info_fixed:Nn \l_@@_value_industrial_mentor_en_tl {12}},
+          {\c_@@_graduate_label_chairman_en_tl} {\@@_secret_info_fixed:Nn \l_@@_value_chairman_en_tl {12}},
           {\c_@@_graduate_label_degree_en_tl} {\l_@@_value_degree_en_tl},
           {\c_@@_graduate_label_major_en_tl} {\l_@@_value_major_en_tl},
           {\c_@@_graduate_label_institute_en_tl} {\l_@@_value_institute_en_tl},
@@ -2623,16 +2641,17 @@
               }
             }
 
+            % 此处必须限制盲审模式替换符号数量，不然会泄露信息，还可能导致行溢出
             \clist_set:Nn \l_@@_input_clist {
               {\c_@@_label_semester_tl} {\l_@@_value_semester_tl},
               {\c_@@_label_school_tl} {\l_@@_value_school_tl},
               {\g_@@_const_info_major_tl} {\l_@@_value_major_tl},
               {\c_@@_label_class_tl} {\@@_secret_info:N \l_@@_value_class_tl},
-              {\c_@@_label_author_tl} {\@@_secret_info:N \l_@@_value_author_tl},
+              {\c_@@_label_author_tl} {\@@_secret_info_fixed:Nn \l_@@_value_author_tl {3}},
               {\c_@@_label_student_id_tl} {\@@_secret_info:N \l_@@_value_student_id_tl},
               {\c_@@_label_course_tl} {\l_@@_value_course_tl},
-              {\c_@@_label_supervisor_tl} {\@@_secret_info:N \l_@@_value_supervisor_tl},
-              {\c_@@_label_co_supervisor_tl} {\@@_secret_info:N \l_@@_value_external_supervisor_tl},
+              {\c_@@_label_supervisor_tl} {\@@_secret_info_fixed:Nn \l_@@_value_supervisor_tl {5}},
+              {\c_@@_label_co_supervisor_tl} {\@@_secret_info_fixed:Nn \l_@@_value_external_supervisor_tl {5}},
               {\c_@@_label_teacher_tl} {\l_@@_value_teacher_tl},
             }
 
@@ -2728,14 +2747,16 @@
 
             \zihao{3}
 
-        % 渲染信息。
+            % 渲染信息。
+            % 此处必须限制盲审模式替换符号数量，不然会泄露信息，还可能导致行溢出
             \clist_set:Nn \l_@@_input_clist {
               {\c_@@_label_school_tl} {\l_@@_value_school_tl},
               {\c_@@_label_major_tl} {\l_@@_value_major_tl},
               {\c_@@_label_class_tl} {\@@_secret_info:N \l_@@_value_class_tl},
-              {\c_@@_label_author_tl} {\@@_secret_info:N \l_@@_value_author_tl},
+              {\c_@@_label_author_tl} {\@@_secret_info_fixed:Nn \l_@@_value_author_tl {3}},
               {\c_@@_label_student_id_tl} {\@@_secret_info:N \l_@@_value_student_id_tl},
-              {\c_@@_label_supervisor_tl} {\@@_secret_info:N \l_@@_value_supervisor_tl},
+              {\c_@@_label_supervisor_tl} {\@@_secret_info_fixed:Nn \l_@@_value_supervisor_tl {5}},
+              % co-supervisor 并非所有人都有，由最终作者自行处理
               {\c_@@_label_co_supervisor_tl} {\@@_secret_info:N \l_@@_value_external_supervisor_tl},
             }
 

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2056,6 +2056,7 @@
 % 这里用 |group| 确保局部变量不会被污染。
     \group_begin:
       \seq_set_eq:NN \l_@@_tmpa_seq #2
+      \dim_zero:N #1
       \dim_zero_new:N \l_@@_tmpa_dim
       \bool_until_do:nn { \seq_if_empty_p:N \l_@@_tmpa_seq }
         {

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -187,8 +187,45 @@ def install_deps(test: TestCase) -> CalledProcessError | None:
             return error
 
 
+def enable_blind_peer_review(test: TestCase) -> CalledProcessError | None:
+    """启用盲审模式"""
+    main = test.directory / "main.tex"
+    main.write_text(
+        re.sub(
+            r"^(\\documentclass\[.+)(\]\{bithesis\})$",
+            r"\1, blindPeerReview=true\2",
+            main.read_text(encoding="utf-8"),
+            count=1,
+            flags=re.MULTILINE,
+        ),
+        encoding="utf-8",
+    )
+
+
+def revert_blind_peer_review(test: TestCase) -> CalledProcessError | None:
+    """取消设置盲审模式"""
+    main = test.directory / "main.tex"
+    main.write_text(
+        re.sub(
+            r"^(\\documentclass\[.+), blindPeerReview=true(\]\{bithesis\})$",
+            r"\1\2",
+            main.read_text(encoding="utf-8"),
+            count=1,
+            flags=re.MULTILINE,
+        ),
+        encoding="utf-8",
+    )
+
+
 TESTS = [
     *(TestCase("📁", d) for d in SCAFFOLD_DIR.iterdir() if d.is_dir()),
+    *(
+        TestCase(
+            "📁🎩", d, pre=[enable_blind_peer_review], post=[revert_blind_peer_review]
+        )
+        for d in SCAFFOLD_DIR.iterdir()
+        if d.is_dir() and "thesis" in d.stem
+    ),
     *(TestCase("🧪", d, pre=[install_deps]) for d in TEST_DIR.iterdir() if d.is_dir()),
     *(
         [


### PR DESCRIPTION
1. 没问题时正常编译
2. 内容超长时发出警告并提示换行
3. 换行后消除警告
4. 盲审模式`***`长度固定，无此问题

<details><summary>截图</summary>

![图片](https://github.com/user-attachments/assets/01e23198-3b93-4cdd-bbc9-824bf54b8414)
![图片](https://github.com/user-attachments/assets/fe38028a-8653-484d-9d0a-7103b347f184)
![图片](https://github.com/user-attachments/assets/5edca274-3136-4ece-b60c-b575dc95e4d9)
![图片](https://github.com/user-attachments/assets/a61f7b3a-dea0-4fdd-8c3a-fbac412b696e)
![图片](https://github.com/user-attachments/assets/fa8cc2c9-f0ca-45e4-b29d-509f2c631099)

</details>

Resolves BITNP#649

已相对 v3.8.4 回归测试，没有区别。
