### PR TITLE
ci(check-links): Ignore CHANGELOG

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -10,3 +10,7 @@ exclude = [
   '^https://www\.tablesgenerator\.com',
   'file://.*/bithesis\.pdf$', # Generated
 ]
+
+exclude_path = [
+  'CHANGELOG.md', # Generated
+]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   build-latex:


### PR DESCRIPTION
CHANGELOG 有许多 GitHub 上的提交链接，导致 429 Too Many Requests。

之前没问题，可能是因为缓存没过期，一点一点加上去，每次量不大。
