### PR TITLE
ci: Fix `make pkg-only`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: handbooks
+          path: handbook
       - run: make pkg-only
       - name: Determine version
         id: version


### PR DESCRIPTION
#627 的 9a6b27f 加了 Download handbooks，但抄少了，没指定路径。

Relates-to: #658
