### PR TITLE
fix(UTE): 给题名页间距增加弹性，以容纳更多内容

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -2825,7 +2825,7 @@
           \currentpdfbookmark{Cover}{pre-frontmatter:cover}
         }
         \begin{titlepage}
-          \vspace*{16mm}
+          \vspace*{16mm minus 16mm}
 
           \centering
 
@@ -2837,16 +2837,16 @@
 
           \zihao{1}\textbf{\ziju{0.12}\l_@@_style_headline_tl}\par
 
-          \vspace{18mm}
+          \vspace{0.5em plus 1fill}
 
           \bool_if:NT \l_@@_cover_add_titlezh_bool {
             \zihao{2}\textbf{\@@_xihei:n \l_@@_value_title_tl}\par
-            \vspace{16mm}
+            \vspace{0.5em plus 0.5fill minus 0.5em}
           }
 
           \zihao{2}\textbf{\@@_xihei:n \l_@@_value_title_en_tl}\par
 
-          \vspace{10mm}
+          \vspace{0.5em plus 1fill}
 
 
           \begin{spacing}{1.8}
@@ -2881,7 +2881,7 @@
             \end{center}
           \end{spacing}
 
-          \vspace*{\fill}
+          \vspace*{1.5em plus 1.5fill}
           \centering
           \zihao{3}\ziju{0.5}\songti{
             \tl_if_empty:NTF \l_@@_cover_date_tl {


### PR DESCRIPTION
英文标题在英文模板比在中文模板大，所以没有照抄中文模板的参数。

Resolves #665

## 极限例子

```latex
% !TeX program = xelatex

\documentclass[type=bachelor_english]{bithesis}

\BITSetup{
  cover = {
    headerImage = images/header.png,
    xiheiFont = STXIHEI.TTF,
  },
  info = {
    title = {证明费马定理 \\ 即所有 $4n + 1$ 形式的质数 \\ 都是两个平方数之和},
    titleEn = {Proof of Fermat's theorem \\ that every prime number of the form $4n + 1$ \\ is the sum of two squares},
    school = Acta Novi Commentarii academiae \\ scientiarum Petropolitanae,
    major = {Demonstratio theorematis Fermatiani omnem numerum primum \\ formae $4n + 1$ esse summam  duorum quadratorum},
    author = Leonhard Euler,
    studentId = {E241, 1760},
    supervisor = Mark R. Snavely and Phil Woodruff,
  },
}

\begin{document}

\MakeCover

\end{document}
```

### After
![图片](https://github.com/user-attachments/assets/f9e8d5b9-05ec-479d-8ed9-4b6b3bbfda66)

### Before
![图片](https://github.com/user-attachments/assets/c3cdb0f4-19d4-4d5d-ae21-978306ac0aeb)
