### PR TITLE
fix: 目录中“第○章”与标题应只空一个字

### DIFF
--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -1580,7 +1580,7 @@
 \@@_if_graduate:TF {
   % 对于研究生模板，定义各章标题为宋体四号。
   \titlecontents{chapter}[0pt]{\songti \zihao{4}}
-  {\thecontentslabel\hspace{\ccwd}}{}
+  {\thecontentslabel\unskip\hspace{\ccwd}}{}
   {\hspace{.5em}\titlerule*{.}\contentspage}
   % section 标题为宋体小四号。缩进为两个字符宽度。
   \titlecontents{section}[2\ccwd]{\songti \zihao{-4}}
@@ -1593,7 +1593,7 @@
 } {
   % 对于其他，定义各章标题为宋体小四号。
   \titlecontents{chapter}[0pt]{\songti \zihao{-4}}
-  {\thecontentslabel\hspace{\ccwd}}{}
+  {\thecontentslabel\unskip\hspace{\ccwd}}{}
   {\hspace{.5em}\titlerule*{.}\contentspage}
   % section 标题为宋体小四号。
   \titlecontents{section}[1\ccwd]{\songti \zihao{-4}}


### PR DESCRIPTION
之前是一个字加一个空格，因为`\thecontentslabel`结尾有空格。

我也不清楚空格哪儿来的……反正 ctexbook 就有。

```latex
% ! TeX program = xelatex
\documentclass{ctexbook}

\usepackage{titletoc}
\titlecontents{chapter}[0pt]{\songti \zihao{4}}
  {\thecontentslabel}{}
  {\hspace{.5em}\titlerule*{.}\contentspage}

\begin{document}
\tableofcontents
\chapter{国}
\end{document}
```

![图片](https://github.com/user-attachments/assets/e5aed3b6-3457-419e-bdd9-0a716efd2708)
![图片](https://github.com/user-attachments/assets/b5218ab8-62e3-463d-8f7f-affd9cd601ae)

