### PR TITLE
ci: Update TeX Live versions (release: 2025, check: 2021 to 2025)

### DIFF
--- a/.explcheckrc
+++ b/.explcheckrc
@@ -5,3 +5,7 @@ ignored_issues = [
   "S204",  # missing stylistic whitespaces
   "W401",  # unused private function
 ]
+
+# Support TeX Live from 2021 to 2025
+l3obsolete_max_deprecated_date = "2021-03-01"
+l3prefixes_max_first_registered_date = "2021-03-01"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: TeX-Live/setup-texlive-action@v3
         with:
-          version: 2024
+          version: 2025
           package-file: |
             .github/tl_packages
       - uses: taiki-e/install-action@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: TeX-Live/setup-texlive-action@v3
         with:
+          version: latest
           packages: |
             scheme-minimal
             xetex

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,11 @@ clean-all: clean clean-dist FORCE_MAKE
 
 .PHONY: check
 check: cls FORCE_MAKE
-	explcheck $(if $(CI),--warnings-are-errors) ./*.cls ./dtx-style.sty $$(fd --extension tex)
+	explcheck $(if $(CI),--warnings-are-errors) ./*.cls ./dtx-style.sty $$(fd --extension tex --exclude bithesis-doc.tex)
+	explcheck $(if $(CI),--warnings-are-errors) --no-config-file bithesis-doc.tex
+# Templates are targeting TeX Live from 2021 to 2025, but docs are targeting the latest TeX Live.
+# Therefore, we check them separately.
+# Example: lt3luabridge introduced `\luabridge_now:n` on 2022-06-25, so it can be used in docs, but not templates.
 
 .PHONY: test
 test: copy FORCE_MAKE

--- a/bithesis.dtx
+++ b/bithesis.dtx
@@ -893,7 +893,7 @@
   bibliographyIndent .bool_set:N = \l_@@_style_bibliography_indent_bool,
   bibliographyIndent .initial:n = {true},
   pageVerticalAlign .choices:nn = {top, scattered} {
-    \tl_if_eq:NnTF \l_keys_choice_tl {top} % noqa: w202
+    \tl_if_eq:NnTF \l_keys_choice_tl {top}
       { \raggedbottom }
       { \flushbottom }
   },
@@ -907,7 +907,7 @@
     asana, bonum, cm, concrete, dejavu, erewhon, euler,
     fira, garamond, gfsneohellenic, kp, libertinus, lm, newcm,
     pagella, schola, stix, stix2, termes, xcharter, xits, none,
-    } { \tl_set_eq:NN \l_@@_style_math_font_tl \l_keys_choice_tl }, % noqa: w202
+    } { \tl_set_eq:NN \l_@@_style_math_font_tl \l_keys_choice_tl },
   mathFont .initial:n = {cm},
   % Options that will be pass to `unicode-math` pkgs.
   unicodeMathOptions .tl_set:N = \l_@@_unicode_math_options_tl,


### PR DESCRIPTION
Thanks to https://github.com/Witiko/expltools/releases/tag/2025-11-24 (explcheck v0.16.0).

Relates-to: 5c72adf
