### PR TITLE
ci: Improve release notes for pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,10 +182,21 @@ jobs:
         id: git-cliff
         with:
           config: cliff.toml
-          args: -vv ${{ github.event.release.prerelease && '--unreleased' || '--latest' }} --strip header
+          # Partially override cliff.toml to generate better release notes.
+          # - For public releases, show changes since the last _public_ release.
+          # - For pre-releases, show changes since the last release (either public or pre-release).
+          # - For testing (workflow_dispatch), show changes not belonging to any release.
+          args: >-
+            -vv
+            --strip header
+            ${{ github.event_name == 'release' && '--current' || '--unreleased' }}
+            ${{ github.event_name == 'release' && (github.event.release.prerelease && '--ignore-tags ""' || '--tag-pattern ''^v\d+\.\d+\.\d+$''') }}
         env:
           OUTPUT: CHANGES.md
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Write release notes to the job summary
+        run: |
+          cat CHANGES.md >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/checkout@v6
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -26,9 +26,21 @@ body = """
   https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
 {%- endmacro -%}
 
-{% if version %}\
+{#- Same as git.ignore_tags in cliff.toml, but won't be overridden from CLI -#}
+{%- set ignore_tags = ".*alpha|beta|-.*" -%}
+
+{% if version and version is not matching(ignore_tags) %}\
+    {#- when generating CHANGELOG.md or release notes for _public_ releases #}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d", timezone="Asia/Shanghai") }}
+{% elif version %}\
+    {#- when generating release notes for _pre_-releases #}\
+    ## [unreleased]
+
+    The following are new unreleased changes \
+    introduced in [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d", timezone="Asia/Shanghai") }} \
+    compared to [{{ previous.version | trim_start_matches(pat="v") }}] - {{ previous.timestamp | date(format="%Y-%m-%d", timezone="Asia/Shanghai") }}.
 {% else %}\
+    {#- when testing #}\
     ## [unreleased]
 {% endif %}\
 {% for group, commits in commits | unique(attribute="id") | group_by(attribute="group") %}


### PR DESCRIPTION
之前没设置好git-cliff（也可能是git-cliff有缺陷），预发布版的发行说明没有东西，例如 https://github.com/BITNP/BIThesis/releases/tag/v3.8.8-alpha.2 。

## 原因分析

（非常混乱，但 git-cliff 2.11.0 似乎确实如此……）

之前给git-cliff指定了`--unreleased`。原以为`git cliff --unreleased`等于`git cliff`结果中的`[unreleased]`部分，实际上只是子集，具体情况要慢慢分析……

git-cliff解析历史时，会把标签分为以下 2+1 = 3 类。分类方法受`ignore_tags`和`tag_pattern`两项设置影响，且CLI设置（见`.github/workflows/release.yml`）会覆盖`cliff.toml`设置（`ignore_tags = ".*alpha|beta|-.*"`；`tag_pattern`未设置，相当于`.*`）。

- 有效标签：匹配`tag_pattern`
  - 正式标签：匹配`tag_pattern`但不匹配`ignore_tags`
  - 非正式标签：匹配`tag_pattern`且匹配`ignore_tags`
- 无效标签：不匹配`tag_pattern`

在changelog模板中，有三个变量相关：

- `version`：当前标签，可能为null

  - 若指定了`--unreleased`，则为null
  - 若指定了`--current`，则为HEAD对应的标签
  - 若指定了`--latest`，则为整个历史中的最新标签

  用 release.published 事件触发 GitHub Actions 时，release 对应的标签已经创建了，所以`--latest`和`--current`效果相同。

- `previous.version`：上一**正式标签**

- `commits`：从上一**有效标签**到当前标签的提交记录

  对于当前标签为null的情况，上一有效标签就是HEAD。

以上理论可以解释目前所有现象。
