### PR TITLE
Add % !TeX root = ../main.tex to all template sub-files to facilitate compilation

### DIFF
--- a/templates/graduate-thesis/chapters/abstract.tex
+++ b/templates/graduate-thesis/chapters/abstract.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 研究生学位论文模板 The BIThesis Template for Graduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/graduate-thesis/chapters/chapter1.tex
+++ b/templates/graduate-thesis/chapters/chapter1.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 研究生学位论文模板 The BIThesis Template for Graduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/graduate-thesis/chapters/chapter2.tex
+++ b/templates/graduate-thesis/chapters/chapter2.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 研究生学位论文模板 The BIThesis Template for Graduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/graduate-thesis/misc/0_symbols.tex
+++ b/templates/graduate-thesis/misc/0_symbols.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 研究生学位论文模板 The BIThesis Template for Graduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/graduate-thesis/misc/1_conclusion.tex
+++ b/templates/graduate-thesis/misc/1_conclusion.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 研究生学位论文模板 The BIThesis Template for Graduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/graduate-thesis/misc/2_reference.tex
+++ b/templates/graduate-thesis/misc/2_reference.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 研究生学位论文模板 The BIThesis Template for Graduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/graduate-thesis/misc/3_appendices.tex
+++ b/templates/graduate-thesis/misc/3_appendices.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 研究生学位论文模板 The BIThesis Template for Graduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/graduate-thesis/misc/4_pub.tex
+++ b/templates/graduate-thesis/misc/4_pub.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 研究生学位论文模板 The BIThesis Template for Graduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/graduate-thesis/misc/5_acknowledgements.tex
+++ b/templates/graduate-thesis/misc/5_acknowledgements.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 研究生学位论文模板 The BIThesis Template for Graduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/graduate-thesis/misc/6_resume.tex
+++ b/templates/graduate-thesis/misc/6_resume.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 研究生学位论文模板 The BIThesis Template for Graduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/paper-translation/chapters/0_abstract.tex
+++ b/templates/paper-translation/chapters/0_abstract.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文翻译模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Bachelor Paper Translation
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/paper-translation/chapters/1_chapter1.tex
+++ b/templates/paper-translation/chapters/1_chapter1.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文翻译模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Bachelor Paper Translation
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/paper-translation/misc/1_conclusion.tex
+++ b/templates/paper-translation/misc/1_conclusion.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文翻译模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Bachelor Paper Translation
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/paper-translation/misc/2_reference.tex
+++ b/templates/paper-translation/misc/2_reference.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文翻译模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Bachelor Paper Translation
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/paper-translation/misc/3_appendix.tex
+++ b/templates/paper-translation/misc/3_appendix.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文翻译模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Bachelor Paper Translation
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/reading-report/chapters/1_chapter1.tex
+++ b/templates/reading-report/chapters/1_chapter1.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 读书报告模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Reading Report
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/reading-report/chapters/2_chapter2.tex
+++ b/templates/reading-report/chapters/2_chapter2.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 读书报告模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Reading Report
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/reading-report/misc/1_conclusion.tex
+++ b/templates/reading-report/misc/1_conclusion.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 读书报告模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Reading Report
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/reading-report/misc/2_reference.tex
+++ b/templates/reading-report/misc/2_reference.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 读书报告模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Reading Report
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis-en/chapters/0_abstract.tex
+++ b/templates/undergraduate-thesis-en/chapters/0_abstract.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板（全英文） —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis-en/chapters/1_chapter1.tex
+++ b/templates/undergraduate-thesis-en/chapters/1_chapter1.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板（全英文） —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis-en/chapters/2_chapter2.tex
+++ b/templates/undergraduate-thesis-en/chapters/2_chapter2.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板（全英文） —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis-en/chapters/3_chapter3.tex
+++ b/templates/undergraduate-thesis-en/chapters/3_chapter3.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板（全英文） —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis-en/misc/1_conclusions.tex
+++ b/templates/undergraduate-thesis-en/misc/1_conclusions.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板（全英文） —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis-en/misc/2_references.tex
+++ b/templates/undergraduate-thesis-en/misc/2_references.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板（全英文） —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis-en/misc/3_appendices.tex
+++ b/templates/undergraduate-thesis-en/misc/3_appendices.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板（全英文） —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis-en/misc/4_acknowledgements.tex
+++ b/templates/undergraduate-thesis-en/misc/4_acknowledgements.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板（全英文） —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis/chapters/0_abstract.tex
+++ b/templates/undergraduate-thesis/chapters/0_abstract.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis/chapters/1_chapter1.tex
+++ b/templates/undergraduate-thesis/chapters/1_chapter1.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis/chapters/2_chapter2.tex
+++ b/templates/undergraduate-thesis/chapters/2_chapter2.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis/misc/1_originality.tex
+++ b/templates/undergraduate-thesis/misc/1_originality.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis/misc/2_conclusion.tex
+++ b/templates/undergraduate-thesis/misc/2_conclusion.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis/misc/3_reference.tex
+++ b/templates/undergraduate-thesis/misc/3_reference.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis/misc/4_appendix.tex
+++ b/templates/undergraduate-thesis/misc/4_appendix.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.

--- a/templates/undergraduate-thesis/misc/5_acknowledgements.tex
+++ b/templates/undergraduate-thesis/misc/5_acknowledgements.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 %%
 % BIThesis 本科毕业设计论文模板 —— 使用 XeLaTeX 编译 The BIThesis Template for Undergraduate Thesis
 % This file has no copyright assigned and is placed in the Public Domain.


### PR DESCRIPTION
LaTeX editors use the `% !TeX root` magic comment to identify the root compilation file. Without it, opening any sub-file (chapters, misc) requires manually switching to `main.tex` to compile.

## Changes

- Prepended `% !TeX root = ../main.tex` as the first line of all 35 tex sub-files across the 5 templates that use sub-files:
  - `graduate-thesis` — 10 files (`chapters/`, `misc/`)
  - `undergraduate-thesis` — 8 files (`chapters/`, `misc/`)
  - `undergraduate-thesis-en` — 8 files (`chapters/`, `misc/`)
  - `paper-translation` — 5 files (`chapters/`, `misc/`)
  - `reading-report` — 4 files (`chapters/`, `misc/`)

All sub-files sit exactly one level below the template root, so `../main.tex` resolves correctly in every case.
