### PR TITLE
fix: 恢复`\parskip`弹性以重新支持跨页对齐底部

### DIFF
--- a/src/bithesis-report.dtx
+++ b/src/bithesis-report.dtx
@@ -521,8 +521,7 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-% 正文 22 磅的行距，段前段后间距为 0
-% \setlength{\parskip}{0em}
+% 正文行距 22 磅
 \cs_set:Npn \baselinestretch {1.53}
 % 正文首行悬挂 1.02cm
 % \setlength{\parindent}{1.02cm}

--- a/src/bithesis-thesis.dtx
+++ b/src/bithesis-thesis.dtx
@@ -1600,8 +1600,8 @@
   % 页码使用阿拉伯数字。
   \pagenumbering{arabic}
   \pagestyle{BIThesis}
-  % 正文 22 磅的行距
-  \setlength{\parskip}{0em}
+  % 正文行距 22 磅，同时略保有弹性以支持 style/pageVerticalAlign = scattered
+  \setlength{\parskip}{0em plus 0.2em}
   \linespread{1.53}\selectfont
   % 修复脚注出现跨页的问题
   \interfootnotelinepenalty=10000


### PR DESCRIPTION
主要影响`style/pageVerticalAlign = scattered`时的效果，`just regression-test`也显示完全不影响默认`style/pageVerticalAlign = top`时的效果。

Resolves #711
