### PR TITLE
fix(GT): 避免「学生类型」触发`Overfull \hbox (6.33167pt too wide)`提示

### DIFF
--- a/src/bithesis-thesis.dtx
+++ b/src/bithesis-thesis.dtx
@@ -2284,9 +2284,9 @@
     \currentpdfbookmark{中文题名页}{pre-frontmatter:titlepage-zh}
   }
   \begin{titlepage}
-      \begin{minipage}[t]{0.48\textwidth}
-        % 密级、分类号
-        {\heiti \zihao{5} \noindent \c_@@_label_classification_tl}
+      \noindent\begin{minipage}[t]{0.48\textwidth}
+        % 分类号、学校代码
+        {\heiti \zihao{5} \c_@@_label_classification_tl}
         \l_@@_value_classification_tl\\
         {\heiti \zihao{5} \c_@@_label_udc_tl}  \l_@@_value_udc_tl\\
         {\heiti \zihao{5} \c_@@_label_university_code_tl}  \l_@@_value_university_code_tl
@@ -2295,7 +2295,7 @@
       \hfill
 
       % 以下内容是「学生类型」的内容，
-      % 在没有勾选的时候隐藏。
+      % 若 cover/showSpecialTypeBox 为 false 且没有任何勾选，则隐藏。
       \bool_if:nT {\l_@@_cover_show_special_type_box_bool || \l_@@_value_international_student_ugp_bool || \l_@@_value_cross_research_bool || \l_@@_value_engineering_special_plan_bool} {
         \begin{minipage}[t]{0.48\textwidth}
           \vspace{-12pt}
@@ -2303,23 +2303,23 @@
           \setlength\fboxrule{1pt}\setlength\fboxsep{3mm}
           \fbox{
             \noindent\begin{minipage}{0.48\linewidth}
-              \heiti \zihao{-4}
+              \heiti \zihao{5}
               \scalebox{1.1}\BigStar{}\hspace{4pt} \c_@@_label_special_type_tl\\
 
               {
-                \zihao{4}
+                \zihao{-4}
                 \bool_if:NTF \l_@@_value_engineering_special_plan_bool {\@@_boxcheck:} {\@@_boxempty:}
               }
               \hspace{1pt}\c_@@_label_engineering_special_plan_tl\\
 
               {
-                \zihao{4}
+                \zihao{-4}
                 \bool_if:NTF \l_@@_value_cross_research_bool {\@@_boxcheck:} {\@@_boxempty:}
               }
               \hspace{1pt}\c_@@_label_cross_research_tl\\
 
               {
-                \zihao{4}
+                \zihao{-4}
                 \bool_if:NTF \l_@@_value_international_student_ugp_bool {\@@_boxcheck:} {\@@_boxempty:}
               }
               \hspace{1pt}\c_@@_label_international_student_ugp_tl


### PR DESCRIPTION
## 背景

2026年4月3日收到反馈，硕博模板启用「学生类型」框时，中文题名页（page 3）会提示以下问题。

```sh
$ texlogsieve --only-summary main.log
Under/overfull boxes:
    page 3 (file ./main.tex):
    Overfull \hbox (6.33167pt too wide) in paragraph at lines 169--169
    Offending text:
    [][] []
```

其实两年前 #419 加这个框时就有问题。不过之前这个框只是“特别”类型，重要性较低，不打勾时为美观而关闭，所以一直没发现；后来改成了“学生”类型，有人反映重要性变高了，不打勾也要显示（#715），所以空模板也触发这个问题了。

## 原因

<details><summary>最小代码</summary>

```latex
\documentclass[type=master]{bithesis}

% \usepackage{lua-visual-debug}

\BITSetup{
  cover = {
    autoWidthPadding = 0.25em,
  },
  info = {
    classification = TQ028.1,
    UDC = 540,
    title = 形状记忆聚氨酯的合成及其在纺织中的应用,
    titleEn = {Synthesis and Application on textile of the Shape Memory Polyurethane},
    author = 张三,
    authorEn = Zhang San,
    studentId = 31xxxxxxxx,
    school = 材料学院,
    schoolEn = Materials Science and Engineering,
    supervisor = 李四教授,  % 指导教师
    supervisorEn = Prof. Li Si,
    chairman = 王五教授,  % 答辩委员会主席
    chairmanEn = Prof. Wang Wu,
    % --- 专业型 ---
    degreeType = professional,
    industrialMentor = 李五教授,  % 行业合作导师
    industrialMentorEn = Prof. Li Wu,
    degree = 材料与化工博士,  % 申请类别
    degreeEn = {Doctor of Materials \\ and Chemical Engineering},
    major = 材料工程,  % 学位领域
    majorEn = Materials Science and Engineering,
  }
}

\begin{document}

\MakeTitle

\end{document}
```

</details>

启用 lua-visual-debug，用lualatex编译在 bf04673 最小代码，得到下图。此处从左到右是：

1. 首行缩进——2em
2. 分类号和学校代码——横向`0.48\textwidth`的minipage
3. `\hfill`——在这里是零。
4. 「学生类型」框——横向`0.48\textwidth`的minipage，套着另一个宽度为`0.48\linewidth`的小minipage

2em + 0.48 textwidth + 0 + textwidth > 页面宽度，所以触发了`Overfull \hbox`提示。

<img width="500" alt="图片" src="https://github.com/user-attachments/assets/64a71667-24df-41df-b033-737fec169907" />

更进一步，修改「学生类型」框内外两层minipage的宽度，发现`Overfull \hbox`提示的具体数值（例如`6.33167pt too wide`）与外层宽度的关系是非齐次一次函数，与内层宽度无关。这就进一步验证了原因。

|外层`\textwidth`倍数|    内层`\linewidth`倍数|      结果|
|--|--|--|
|0.49 |  0.48|     10.77463pt too wide|
|0.48 |  1     |   6.33167pt too wide + 19.07162pt too wide|
|0.48 |  0.48|     6.33167pt too wide|
|0.48 |  0.47|     6.33167pt too wide|
|0.48 |  0.40|     6.33167pt too wide + 折行|
|0.47 |  0.48|     1.89546pt too wide|
|0.46 |  0.48|     正常|
|0.44 |  0.48|     正常|
|0.40 |  0.48|     折行|

## 解决方案

把分类号和学校代码之前的首行缩进去掉。

<img width="500" alt="图片" src="https://github.com/user-attachments/assets/9ac39fcf-f632-4085-9c65-49f4ff8158b9" />


## 其它修改

顺便调小了「学生类型」框的字号。之前为小四（12点），现在为五号（10.5点），与分类号和学校代码一致。
今年Word模板分类号和学校代码是五号（10.5点），「学生类型」框是11点。

另外还更新了过时注释。

## 回归测试

`just regressions-test`显示只有这处修改，符合预期。

<img width="601" height="497" alt="图片" src="https://github.com/user-attachments/assets/c1cb59fc-f192-420a-b5ba-42de98b9ccf0" />
