### PR TITLE
参照硕博最新Word模板修改

### DIFF
--- a/src/bithesis-thesis.dtx
+++ b/src/bithesis-thesis.dtx
@@ -433,7 +433,7 @@
       {Degree~by},
     {submission_date}
       {论\@@_smallgap: 文\@@_smallgap: 提\@@_smallgap: 交\@@_smallgap: 日\@@_smallgap: 期}
-      {Submission~date~of~the~paper},
+      {Submission~date},
   } {\@@_define_label_by_thesis_type:nnnn {graduate} #1}
 %    \end{macrocode}
 % \end{variable}

--- a/templates/graduate-thesis/main.tex
+++ b/templates/graduate-thesis/main.tex
@@ -60,7 +60,7 @@
     % --- 学术型 ---
     % degreeType = academic,
     % degree = 工学博士,  % 申请学位
-    % degreeEn = Doctor of Engineering,
+    % degreeEn = Doctor of Philosophy,
     % major = 材料科学与工程,  % 一级学科
     % majorEn = Materials Science and Engineering,
     %


### PR DESCRIPTION
研院近期陆续收到学生或老师反馈的一些细节问题，就顺手改了Word模板。

[Word元数据「上次修改时间」为4月27日15:21的版本](https://web.archive.org/web/20260429124718/https://grd.bit.edu.cn/xwgz/xwgz2/wjxz_xwgz/b119746.htm)，与[3月31日最初发布的版本](https://web.archive.org/web/20260331091541/https://grd.bit.edu.cn/xwgz/xwgz2/wjxz_xwgz/b119746.htm)相比，有如下变化。

- 将英文题名页的 Submission date of the paper 改为 Submission date（此PR）
- 学术型 Materials Science and Engineering 对应的 Degree Applied 从 Doctor of Engineering 变成了 Doctor of Philosophy（此PR）
- 英文摘要页的冒号、分号后加了空格（BIThesis本就如此）
- 参考文献只保留了两条示例（与BIThesis无关）
- 参考文献、成果清单中的“：”改成了“:”（BIThesis本就如此）

与研究生院老师沟通时，也顺便反馈了 #735 发现的问题。

Continues #724
